### PR TITLE
FA11y v17.4

### DIFF
--- a/FA11y.py
+++ b/FA11y.py
@@ -446,9 +446,24 @@ def main() -> None:
         print(f"An error occurred: {str(e)}")
         speaker.speak(f"An error occurred: {str(e)}")
     finally:
+        # Clean up operations
         stop_key_listener.set()
         if storm_detector:
             storm_detector.stop_monitoring()
+
+        # Clean up any remaining tkinter variables
+        if 'tk' in sys.modules:
+            try:
+                import tkinter as tk
+                if tk._default_root:
+                    # Destroy any remaining tkinter windows
+                    for widget in tk._default_root.winfo_children():
+                        widget.destroy()
+                    tk._default_root.destroy()
+                    tk._default_root = None
+            except Exception:
+                pass
+
         print("FA11y is closing...")
         sys.exit(0)
 

--- a/lib/hsr.py
+++ b/lib/hsr.py
@@ -1,5 +1,6 @@
 from PIL import ImageGrab
 from accessible_output2.outputs.auto import Auto
+from lib.utilities import read_config, get_config_boolean
 
 speaker = Auto()
 health_color, shield_color = (158, 255, 99), (110, 235, 255)
@@ -15,13 +16,24 @@ def pixel_within_tolerance(pixel_color, target_color, tol):
     return all(abs(pc - tc) <= tol for pc, tc in zip(pixel_color, target_color))
 
 def check_value(pixels, start_x, y, decreases, color, tolerance, name, no_value_msg):
+    """
+    Check health/shield values and announce with simplified speech if enabled.
+    """
+    config = read_config()
+    simplify = get_config_boolean(config, 'SimplifySpeechOutput', False)
+    
     x = start_x
     for i in range(100, 0, -1):
         if pixel_within_tolerance(pixels[x, y], color, tolerance):
-            speaker.speak(f'{i} {name}')
+            if simplify:
+                speaker.speak(str(i))
+            else:
+                speaker.speak(f'{i} {name}')
             return
-        x -= decreases[i % len(decreases)]
-    speaker.speak(no_value_msg)
+    if simplify:
+        speaker.speak('0')
+    else:
+        speaker.speak(no_value_msg)
 
 def check_rarity():
     screenshot = ImageGrab.grab(bbox=(0, 0, 1920, 1080))

--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -17,6 +17,7 @@ CONFIG_FILE = 'config.txt'
 
 # Modified DEFAULT_CONFIG to use new section format
 DEFAULT_CONFIG = """[Toggles]
+SimplifySpeechOutput = false "Toggles simplifying speech for various FA11y announcements."
 MouseKeys = true "Toggles the keybinds used to look around, left click, and right click."
 ResetSensitivity = false "Toggles between two sensitivity values for certain mouse movements, like recentering the camera. Do not change this if you are a new player."
 AnnounceWeaponAttachments = true "Toggles the announcements of weapon attachments when equipping weapons."


### PR DESCRIPTION
# FA11y v17.4

## Updated
- Updated speech patterns throughout FA11y to be shorter and more concise when using the new "SimplifySpeechOutput" toggle. This makes speech feedback faster and clearer when enabled.
- Updated navigation messages to consistently announce distance before direction (e.g., "WHIFFY WHARF 1254 meters in front and to the left" instead of "WHIFFY WHARF in front and to the left 1254 meters").
- Updated GUI cleanup code to properly handle tkinter resources, preventing error messages when closing FA11y or its configuration windows.

## Added
- Added new "SimplifySpeechOutput" toggle (defaults to FALSE) which enables shorter speech patterns:
  - Health/Shields: "100" "50" instead of "100 health" "50 shields"
  - Ammo counts: "20 mag 60 reserves" instead of "with 20 ammo in the mag and 60 in reserves"
  - Consumables: "3 uses" instead of "You have 3 uses left"
  - Navigation: Removes the announcement of the direction the player is facing at the end, and removes some filler words
- Added the announcement of consumable item counts when equipped

## Fixed
- Fixed an issue where closing FA11y's configuration windows could cause tkinter-related error messages
- Fixed cleanup of tkinter resources when exiting FA11y to prevent runtime errors during shutdown