### PR TITLE
Fix ranked tier progression - reverse tier arrays

### DIFF
--- a/lib/guis/social_gui.py
+++ b/lib/guis/social_gui.py
@@ -136,23 +136,26 @@ class SocialDialog(AccessibleDialog):
         return panel
 
     def _division_to_rank_name(self, division: int) -> str:
-        """Convert division number to human-readable rank name"""
+        """
+        Convert division number to human-readable rank name
+        In Fortnite: I is lowest, II is middle, III is highest within each tier
+        """
         if division == 0:
             return "Unranked"
         elif 1 <= division <= 3:
-            tier = ["III", "II", "I"][division - 1]
+            tier = ["I", "II", "III"][division - 1]
             return f"Bronze {tier}"
         elif 4 <= division <= 6:
-            tier = ["III", "II", "I"][division - 4]
+            tier = ["I", "II", "III"][division - 4]
             return f"Silver {tier}"
         elif 7 <= division <= 9:
-            tier = ["III", "II", "I"][division - 7]
+            tier = ["I", "II", "III"][division - 7]
             return f"Gold {tier}"
         elif 10 <= division <= 12:
-            tier = ["III", "II", "I"][division - 10]
+            tier = ["I", "II", "III"][division - 10]
             return f"Platinum {tier}"
         elif 13 <= division <= 15:
-            tier = ["III", "II", "I"][division - 13]
+            tier = ["I", "II", "III"][division - 13]
             return f"Diamond {tier}"
         elif division == 16:
             return "Elite"

--- a/lib/managers/social_manager.py
+++ b/lib/managers/social_manager.py
@@ -329,23 +329,26 @@ class SocialManager:
             logger.error(f"Error refreshing slow data: {e}")
 
     def _division_to_rank_name(self, division: int) -> str:
-        """Convert division number to human-readable rank name"""
+        """
+        Convert division number to human-readable rank name
+        In Fortnite: I is lowest, II is middle, III is highest within each tier
+        """
         if division == 0:
             return "Unranked"
         elif 1 <= division <= 3:
-            tier = ["III", "II", "I"][division - 1]
+            tier = ["I", "II", "III"][division - 1]
             return f"Bronze {tier}"
         elif 4 <= division <= 6:
-            tier = ["III", "II", "I"][division - 4]
+            tier = ["I", "II", "III"][division - 4]
             return f"Silver {tier}"
         elif 7 <= division <= 9:
-            tier = ["III", "II", "I"][division - 7]
+            tier = ["I", "II", "III"][division - 7]
             return f"Gold {tier}"
         elif 10 <= division <= 12:
-            tier = ["III", "II", "I"][division - 10]
+            tier = ["I", "II", "III"][division - 10]
             return f"Platinum {tier}"
         elif 13 <= division <= 15:
-            tier = ["III", "II", "I"][division - 13]
+            tier = ["I", "II", "III"][division - 13]
             return f"Diamond {tier}"
         elif division == 16:
             return "Elite"


### PR DESCRIPTION
Fixed incorrect rank tier ordering where divisions were mapped backwards. In Fortnite's ranking system, tier I is the lowest and tier III is the highest within each rank (Bronze, Silver, Gold, Platinum, Diamond).

The tier arrays were incorrectly mapping:
- Division 1 → Tier III (should be Tier I)
- Division 2 → Tier II (correct by coincidence)
- Division 3 → Tier I (should be Tier III)

This caused incorrect progression announcements like: "Promoted to Bronze II (20% towards Bronze I)"
when it should have been:
"Promoted to Bronze II (20% towards Bronze III)"

Changes:
- Fixed tier arrays in _division_to_rank_name in both social_manager.py and social_gui.py from ["III", "II", "I"] to ["I", "II", "III"]
- Added clarifying comment about Fortnite's tier ordering
- Affects Bronze, Silver, Gold, Platinum, and Diamond tiers

Now correctly displays progression from lower to higher tiers: Bronze I → Bronze II → Bronze III → Silver I, etc.