### PR TITLE
Add ranked progress announcements for percentage changes

### DIFF
--- a/lib/managers/social_manager.py
+++ b/lib/managers/social_manager.py
@@ -394,6 +394,7 @@ class SocialManager:
                 if ranking_type in self.prev_ranked_progress and not first_run:
                     prev_data = self.prev_ranked_progress[ranking_type]
                     prev_div = prev_data.get('currentDivision', 0)
+                    prev_progress = prev_data.get('promotionProgress', 0.0)
 
                     # Check for division change (promotion or demotion)
                     # Only announce if there's an actual change and player is ranked (not unranked)
@@ -418,6 +419,20 @@ class SocialManager:
                             announcement = f"{mode_name} ranked: Demoted to {current_rank}."
                             speaker.speak(announcement)
                             logger.info(f"Ranked demotion: {announcement}")
+
+                    # Check for progress change within the same division
+                    elif current_div == prev_div and current_div > 0:
+                        # Only announce if progress has changed
+                        if current_progress != prev_progress:
+                            mode_name = self._get_ranked_mode_name(ranking_type)
+                            current_rank = self._division_to_rank_name(current_div + 1)
+                            next_div = current_div + 2
+                            next_rank = self._division_to_rank_name(next_div)
+                            progress_pct = int(current_progress * 100)
+
+                            announcement = f"{mode_name} ranked: {progress_pct}% towards {next_rank}"
+                            speaker.speak(announcement)
+                            logger.info(f"Ranked progress update: {current_rank} - {announcement}")
 
                 # Update previous state (silent on first run)
                 self.prev_ranked_progress[ranking_type] = {


### PR DESCRIPTION
Previously, the system only announced rank changes when you were promoted or demoted to a different division. It did not announce progress percentage changes within the same rank.

Now announces when your progress percentage changes within your current division, e.g., when you go from 20% to 22% in Bronze II.

Changes:
- Added progress tracking for previous promotionProgress value
- Added elif block to check for progress changes within same division
- Announces: "[Mode] ranked: [X]% towards [Next Rank]"
- Example: "Battle Royale ranked: 22% towards Bronze III"

The announcement triggers on any progress change, allowing the user to track their ranked progression in real-time even when they haven't been promoted yet.