### PR TITLE
Replace pyautogui pixel checks with FA11y screen capture

### DIFF
--- a/lib/guis/discovery_gui.py
+++ b/lib/guis/discovery_gui.py
@@ -16,6 +16,7 @@ from lib.guis.gui_utilities import (
     messageBox, BORDER_FOR_DIALOGS
 )
 from lib.utilities.window_utils import focus_fortnite
+from lib.managers.screenshot_manager import capture_coordinates
 
 logger = logging.getLogger(__name__)
 speaker = Auto()
@@ -1146,8 +1147,17 @@ class DiscoveryDialog(AccessibleDialog):
                 pyautogui.press('enter')
 
                 # Wait for search results - check if pixel 84,335 is white (255,255,255)
+                # Using FA11y's built-in screen capture instead of pyautogui
+                def check_pixel_white(x, y):
+                    """Check if pixel at (x, y) is white using FA11y screen capture"""
+                    pixel = capture_coordinates(x, y, 1, 1, 'rgb')
+                    if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
+                        color = tuple(pixel[0, 0])
+                        return color == (255, 255, 255)
+                    return False
+
                 start_time = time.time()
-                while not pyautogui.pixelMatchesColor(84, 335, (255, 255, 255)):
+                while not check_pixel_white(84, 335):
                     if time.time() - start_time > 5:
                         logger.error("Timeout waiting for search results")
                         speaker.speak("Failed to select gamemode: Search results not found - gamemode may not exist or something else broke")

--- a/lib/guis/gamemode_gui.py
+++ b/lib/guis/gamemode_gui.py
@@ -19,6 +19,7 @@ from lib.guis.gui_utilities import (
     center_mouse_in_window, BORDER_FOR_DIALOGS
 )
 from lib.utilities.window_utils import focus_fortnite
+from lib.managers.screenshot_manager import capture_coordinates
 
 # Initialize logger
 logger = logging.getLogger(__name__)
@@ -210,8 +211,17 @@ class GamemodeGUI(AccessibleDialog):
             pyautogui.press('enter')
 
             # Wait for search results - check if pixel 84,335 is white (255,255,255)
+            # Using FA11y's built-in screen capture instead of pyautogui
+            def check_pixel_white(x, y):
+                """Check if pixel at (x, y) is white using FA11y screen capture"""
+                pixel = capture_coordinates(x, y, 1, 1, 'rgb')
+                if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
+                    color = tuple(pixel[0, 0])
+                    return color == (255, 255, 255)
+                return False
+
             start_time = time.time()
-            while not pyautogui.pixelMatchesColor(84, 335, (255, 255, 255)):
+            while not check_pixel_white(84, 335):
                 if time.time() - start_time > 5:
                     logger.error("Timeout waiting for search results")
                     pyautogui.scroll(3)


### PR DESCRIPTION
Updated both gamemode_gui.py and discovery_gui.py to use FA11y's built-in screen capture (capture_coordinates) instead of pyautogui.pixelMatchesColor for checking if search results have loaded. This aligns with the pattern used throughout the rest of the codebase and provides more consistent screen capture behavior.

Changes:
- Added import for capture_coordinates from screenshot_manager
- Created check_pixel_white() helper function using capture_coordinates
- Replaced pyautogui.pixelMatchesColor(84, 335, (255, 255, 255)) calls with check_pixel_white(84, 335) in both files