### PR TITLE
Add debug output for pixel color checks

### DIFF
--- a/lib/guis/discovery_gui.py
+++ b/lib/guis/discovery_gui.py
@@ -1153,7 +1153,9 @@ class DiscoveryDialog(AccessibleDialog):
                     pixel = capture_coordinates(x, y, 1, 1, 'rgb')
                     if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
                         color = tuple(pixel[0, 0])
+                        print(f"Pixel at ({x}, {y}): {color}")
                         return color == (255, 255, 255)
+                    print(f"Pixel at ({x}, {y}): None (capture failed)")
                     return False
 
                 start_time = time.time()

--- a/lib/guis/gamemode_gui.py
+++ b/lib/guis/gamemode_gui.py
@@ -217,7 +217,9 @@ class GamemodeGUI(AccessibleDialog):
                 pixel = capture_coordinates(x, y, 1, 1, 'rgb')
                 if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
                     color = tuple(pixel[0, 0])
+                    print(f"Pixel at ({x}, {y}): {color}")
                     return color == (255, 255, 255)
+                print(f"Pixel at ({x}, {y}): None (capture failed)")
                 return False
 
             start_time = time.time()


### PR DESCRIPTION
Added print statements to display the pixel position and color when checking for search results. This will help debug the screen capture functionality by showing what color values are being detected at position (84, 335).