### PR TITLE
Add comparison debug output between FA11y and PyAutoGUI pixel reads

### DIFF
--- a/lib/guis/discovery_gui.py
+++ b/lib/guis/discovery_gui.py
@@ -1150,12 +1150,20 @@ class DiscoveryDialog(AccessibleDialog):
                 # Using FA11y's built-in screen capture instead of pyautogui
                 def check_pixel_white(x, y):
                     """Check if pixel at (x, y) is white using FA11y screen capture"""
+                    # Capture using FA11y
                     pixel = capture_coordinates(x, y, 1, 1, 'rgb')
+
+                    # Also get pyautogui's version for comparison
+                    try:
+                        pyautogui_color = pyautogui.pixel(x, y)
+                    except:
+                        pyautogui_color = "error"
+
                     if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
-                        color = tuple(pixel[0, 0])
-                        print(f"Pixel at ({x}, {y}): {color}")
-                        return color == (255, 255, 255)
-                    print(f"Pixel at ({x}, {y}): None (capture failed)")
+                        fa11y_color = tuple(pixel[0, 0])
+                        print(f"Position ({x}, {y}) - FA11y: {fa11y_color}, PyAutoGUI: {pyautogui_color}")
+                        return fa11y_color == (255, 255, 255)
+                    print(f"Position ({x}, {y}) - FA11y: None (capture failed), PyAutoGUI: {pyautogui_color}")
                     return False
 
                 start_time = time.time()

--- a/lib/guis/gamemode_gui.py
+++ b/lib/guis/gamemode_gui.py
@@ -214,12 +214,20 @@ class GamemodeGUI(AccessibleDialog):
             # Using FA11y's built-in screen capture instead of pyautogui
             def check_pixel_white(x, y):
                 """Check if pixel at (x, y) is white using FA11y screen capture"""
+                # Capture using FA11y
                 pixel = capture_coordinates(x, y, 1, 1, 'rgb')
+
+                # Also get pyautogui's version for comparison
+                try:
+                    pyautogui_color = pyautogui.pixel(x, y)
+                except:
+                    pyautogui_color = "error"
+
                 if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
-                    color = tuple(pixel[0, 0])
-                    print(f"Pixel at ({x}, {y}): {color}")
-                    return color == (255, 255, 255)
-                print(f"Pixel at ({x}, {y}): None (capture failed)")
+                    fa11y_color = tuple(pixel[0, 0])
+                    print(f"Position ({x}, {y}) - FA11y: {fa11y_color}, PyAutoGUI: {pyautogui_color}")
+                    return fa11y_color == (255, 255, 255)
+                print(f"Position ({x}, {y}) - FA11y: None (capture failed), PyAutoGUI: {pyautogui_color}")
                 return False
 
             start_time = time.time()


### PR DESCRIPTION
Added side-by-side comparison of pixel color values from both FA11y's capture_coordinates and PyAutoGUI's pixel() function. This will help identify coordinate system mismatches, DPI scaling issues, or other discrepancies between the two methods.

Debug output format:
Position (x, y) - FA11y: (R, G, B), PyAutoGUI: (R, G, B)