### PR TITLE
Add debug screenshot capture on timeout and pixel test script

### DIFF
--- a/lib/guis/discovery_gui.py
+++ b/lib/guis/discovery_gui.py
@@ -1167,9 +1167,26 @@ class DiscoveryDialog(AccessibleDialog):
                     return False
 
                 start_time = time.time()
+                check_count = 0
                 while not check_pixel_white(84, 335):
                     if time.time() - start_time > 5:
                         logger.error("Timeout waiting for search results")
+                        # Save a debug screenshot on timeout
+                        try:
+                            from lib.managers.screenshot_manager import screenshot_manager
+                            import cv2
+                            debug_shot = screenshot_manager.capture_full_screen('rgb')
+                            if debug_shot is not None:
+                                # Draw a marker at the pixel we were checking
+                                debug_shot_bgr = cv2.cvtColor(debug_shot, cv2.COLOR_RGB2BGR)
+                                cv2.circle(debug_shot_bgr, (84, 335), 10, (0, 0, 255), 2)
+                                cv2.putText(debug_shot_bgr, f"(84,335)", (94, 335),
+                                           cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 1)
+                                cv2.imwrite('discovery_gui_timeout_debug.png', debug_shot_bgr)
+                                print(f"[DEBUG] Saved timeout screenshot to discovery_gui_timeout_debug.png")
+                        except Exception as e:
+                            print(f"[DEBUG] Failed to save debug screenshot: {e}")
+
                         speaker.speak("Failed to select gamemode: Search results not found - gamemode may not exist or something else broke")
                         pyautogui.scroll(3)
                         time.sleep(0.2)
@@ -1179,6 +1196,7 @@ class DiscoveryDialog(AccessibleDialog):
                         time.sleep(0.2)
                         pyautogui.scroll(3)
                         return
+                    check_count += 1
                     time.sleep(0.1)
                 time.sleep(0.1)
 

--- a/lib/guis/gamemode_gui.py
+++ b/lib/guis/gamemode_gui.py
@@ -231,9 +231,26 @@ class GamemodeGUI(AccessibleDialog):
                 return False
 
             start_time = time.time()
+            check_count = 0
             while not check_pixel_white(84, 335):
                 if time.time() - start_time > 5:
                     logger.error("Timeout waiting for search results")
+                    # Save a debug screenshot on timeout
+                    try:
+                        from lib.managers.screenshot_manager import screenshot_manager
+                        import cv2
+                        debug_shot = screenshot_manager.capture_full_screen('rgb')
+                        if debug_shot is not None:
+                            # Draw a marker at the pixel we were checking
+                            debug_shot_bgr = cv2.cvtColor(debug_shot, cv2.COLOR_RGB2BGR)
+                            cv2.circle(debug_shot_bgr, (84, 335), 10, (0, 0, 255), 2)
+                            cv2.putText(debug_shot_bgr, f"(84,335)", (94, 335),
+                                       cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 1)
+                            cv2.imwrite('gamemode_selector_timeout_debug.png', debug_shot_bgr)
+                            print(f"[DEBUG] Saved timeout screenshot to gamemode_selector_timeout_debug.png")
+                    except Exception as e:
+                        print(f"[DEBUG] Failed to save debug screenshot: {e}")
+
                     pyautogui.scroll(3)
                     time.sleep(0.2)
                     pyautogui.scroll(3)
@@ -242,6 +259,7 @@ class GamemodeGUI(AccessibleDialog):
                     time.sleep(0.2)
                     pyautogui.scroll(3)
                     return (False, "Search results not found - gamemode may not exist or something else broke")
+                check_count += 1
                 time.sleep(0.1)
             time.sleep(0.1)
 

--- a/test_pixel_84_335.py
+++ b/test_pixel_84_335.py
@@ -1,0 +1,43 @@
+"""
+Test script to check pixel at (84, 335) using both methods
+Run this while you have the search results visible to verify the pixel color
+"""
+import pyautogui
+from lib.managers.screenshot_manager import capture_coordinates, screenshot_manager
+
+print("Testing pixel at position (84, 335)...")
+print("=" * 60)
+
+# Method 1: PyAutoGUI
+try:
+    pyautogui_color = pyautogui.pixel(84, 335)
+    print(f"PyAutoGUI pixel(84, 335): {pyautogui_color}")
+except Exception as e:
+    print(f"PyAutoGUI error: {e}")
+
+# Method 2: FA11y capture_coordinates (1x1 region)
+try:
+    pixel = capture_coordinates(84, 335, 1, 1, 'rgb')
+    if pixel is not None and pixel.shape[0] > 0 and pixel.shape[1] > 0:
+        fa11y_color = tuple(pixel[0, 0])
+        print(f"FA11y capture_coordinates(84, 335, 1, 1): {fa11y_color}")
+    else:
+        print("FA11y capture_coordinates: Failed")
+except Exception as e:
+    print(f"FA11y error: {e}")
+
+# Method 3: FA11y full screen (like dev tool does)
+try:
+    full_screen = screenshot_manager.capture_full_screen('rgb')
+    if full_screen is not None:
+        # Note: numpy arrays are indexed [y, x] not [x, y]
+        dev_tool_color = tuple(full_screen[335, 84])
+        print(f"FA11y full_screen[335, 84] (dev tool method): {dev_tool_color}")
+    else:
+        print("FA11y full_screen: Failed")
+except Exception as e:
+    print(f"FA11y full_screen error: {e}")
+
+print("=" * 60)
+print("\nRun this script with the search results visible on screen")
+print("to see what the pixel actually is at (84, 335)")


### PR DESCRIPTION
Changes:
- Added debug screenshot saving on timeout in both gamemode_gui and discovery_gui
- Screenshot shows exactly what's on screen when pixel check times out
- Red circle marker shows the exact pixel position being checked (84, 335)
- Created test_pixel_84_335.py to manually verify pixel colors using all methods
- Debug screenshots saved to gamemode_selector_timeout_debug.png / discovery_gui_timeout_debug.png

This will help identify if the issue is:
1. Wrong pixel position
2. Search results not loading
3. Timing issues
4. Focus/window issues