### PR TITLE
Fix: unify FakerInput into single shared connection

### DIFF
--- a/lib/mouse_passthrough/faker_input.py
+++ b/lib/mouse_passthrough/faker_input.py
@@ -160,6 +160,75 @@ def send_mouse_move(dx, dy, cache_range):
         return False
 
 
+def send_mouse_button(button_name, is_down, cache_range=100):
+    """Send a mouse button press/release through FakerInput.
+
+    Args:
+        button_name: Button name (e.g. "LeftButton", "RightButton", "MiddleButton")
+        is_down: True for press, False for release
+        cache_range: Cache range for initialization if needed
+    """
+    global _faker_input, _mouse_report, _initialized, _System
+
+    if not _initialized:
+        if not initialize_fakerinput(cache_range):
+            return False
+
+    try:
+        method_name = "ButtonDown" if is_down else "ButtonUp"
+        button_method = _RelativeMouseReportType.GetMethod(method_name)
+
+        if button_method:
+            button_enum = _System.Enum.Parse(_MouseButtonType, button_name)
+            args_array = _System.Array[_System.Object]([button_enum])
+            button_method.Invoke(_mouse_report, args_array)
+
+            args = _System.Array[_System.Object]([_mouse_report])
+            _update_method.Invoke(_faker_input, args)
+            return True
+    except Exception as e:
+        print(f"[ERROR] Mouse button {button_name} {'down' if is_down else 'up'}: {e}")
+
+    return False
+
+
+def send_mouse_scroll(amount, cache_range=100):
+    """Send a mouse scroll event through FakerInput.
+
+    Args:
+        amount: Scroll amount (-127 to 127, negative = scroll down)
+        cache_range: Cache range for initialization if needed
+    """
+    global _faker_input, _mouse_report, _initialized, _System
+
+    if not _initialized:
+        if not initialize_fakerinput(cache_range):
+            return False
+
+    try:
+        wheel_property = _RelativeMouseReportType.GetProperty("WheelPosition")
+
+        wheel_value = max(-127, min(127, amount))
+        if wheel_value < 0:
+            wheel_value += 256
+
+        wheel_property.SetValue(_mouse_report, _System.Byte(wheel_value))
+
+        args = _System.Array[_System.Object]([_mouse_report])
+        _update_method.Invoke(_faker_input, args)
+
+        wheel_property.SetValue(_mouse_report, _System.Byte(0))
+        return True
+    except Exception as e:
+        print(f"[ERROR] Mouse scroll: {e}")
+        return False
+
+
 def is_available():
     """Check if FakerInput is available and loaded."""
     return FAKERINPUT_AVAILABLE
+
+
+def is_initialized():
+    """Check if FakerInput is initialized and connected."""
+    return _initialized

--- a/lib/utilities/mouse.py
+++ b/lib/utilities/mouse.py
@@ -1,9 +1,17 @@
 import ctypes
 import time
 import threading
-import os
 from typing import Tuple
 from lib.utilities.utilities import get_config_int, get_config_float, read_config
+from lib.mouse_passthrough.faker_input import (
+    send_mouse_move as _fi_send_mouse_move,
+    send_mouse_button as _fi_send_mouse_button,
+    send_mouse_scroll as _fi_send_mouse_scroll,
+    is_available as _fi_is_available,
+    is_initialized as _fi_is_initialized,
+    initialize_fakerinput as _fi_initialize,
+    FAKERINPUT_AVAILABLE,
+)
 
 # Global configuration
 config = read_config()
@@ -12,130 +20,59 @@ config = read_config()
 _movement_lock = threading.Lock()
 _current_movement_thread = None
 
-# FakerInput globals
-FAKERINPUT_AVAILABLE = False
-_faker_input = None
-_mouse_report = None
-_initialized = False
-_System = None
+# Default cache range matching mouse_passthrough config default
+_CACHE_RANGE = 100
 
-# Load FakerInput
-try:
-    import pythonnet
-    from pythonnet import set_runtime
-    set_runtime("coreclr")
-    import clr
-    import System
-    _System = System
-    
-    dll_path = os.path.abspath("FakerInputWrapper.dll")
-    if os.path.exists(dll_path):
-        try:
-            import subprocess
-            subprocess.run(['powershell', '-Command', f'Unblock-File -Path "{dll_path}"'], 
-                          capture_output=True)
-        except:
-            pass
-        
-        _assembly = System.Reflection.Assembly.LoadFrom(dll_path)
-        _FakerInputType = _assembly.GetType('FakerInputWrapper.FakerInput')
-        _RelativeMouseReportType = _assembly.GetType('FakerInputWrapper.RelativeMouseReport')
-        _MouseButtonType = _assembly.GetType('FakerInputWrapper.MouseButton')
-        
-        if _FakerInputType and _RelativeMouseReportType and _MouseButtonType:
-            FAKERINPUT_AVAILABLE = True
-except Exception:
-    pass
 
-def initialize_fakerinput():
-    """Initialize FakerInput"""
-    global _faker_input, _mouse_report, _initialized
-    
-    if not FAKERINPUT_AVAILABLE or _initialized:
-        return _initialized
-    
-    try:
-        _faker_input = _System.Activator.CreateInstance(_FakerInputType)
-        _mouse_report = _System.Activator.CreateInstance(_RelativeMouseReportType)
-        
-        connect_method = _FakerInputType.GetMethod("Connect")
-        if connect_method.Invoke(_faker_input, None):
-            _initialized = True
-            print("FakerInput connected successfully")
-    except Exception as e:
-        print(f"FakerInput initialization failed: {e}")
-    
-    return _initialized
+def _ensure_initialized():
+    """Ensure FakerInput is initialized via the shared connection."""
+    if not _fi_is_initialized():
+        return _fi_initialize(_CACHE_RANGE)
+    return True
+
 
 def _send_mouse_button(button_name, is_down):
-    """Internal function to send mouse button events"""
-    if not _initialized and not initialize_fakerinput():
-        return False
-    
-    try:
-        method_name = "ButtonDown" if is_down else "ButtonUp"
-        button_method = _RelativeMouseReportType.GetMethod(method_name)
-        
-        if button_method:
-            button_enum = _System.Enum.Parse(_MouseButtonType, button_name)
-            args_array = _System.Array[_System.Object]([button_enum])
-            button_method.Invoke(_mouse_report, args_array)
-            
-            update_method = _FakerInputType.GetMethod("UpdateRelativeMouse")
-            update_args = _System.Array[_System.Object]([_mouse_report])
-            update_method.Invoke(_faker_input, update_args)
-            return True
-    except Exception as e:
-        print(f"Mouse button {button_name} {method_name} error: {e}")
-    
-    return False
+    """Internal function to send mouse button events via shared FakerInput."""
+    return _fi_send_mouse_button(button_name, is_down, _CACHE_RANGE)
+
 
 def smooth_move_mouse(dx: int, dy: int, step_delay: float = 0.01, steps: int = None, step_speed: int = None, second_dy: int = None, recenter_delay: float = None):
-    """Move mouse smoothly with steps using FakerInput"""
+    """Move mouse smoothly with steps using shared FakerInput."""
     global _current_movement_thread
-    
+
     if steps is None:
         steps = get_config_int(config, 'TurnSteps', 5)
     if step_speed is None:
         step_speed = get_config_int(config, 'RecenterStepSpeed', 0)
-    
+
     step_speed_seconds = step_speed / 1000.0
-    
-    if not FAKERINPUT_AVAILABLE or not (_initialized or initialize_fakerinput()):
+
+    if not _fi_is_available():
         return False
-    
+    if not _fi_is_initialized():
+        if not _fi_initialize(_CACHE_RANGE):
+            return False
+
     def move():
         with _movement_lock:
             try:
-                mousex_property = _RelativeMouseReportType.GetProperty("MouseX")
-                mousey_property = _RelativeMouseReportType.GetProperty("MouseY")
-                update_method = _FakerInputType.GetMethod("UpdateRelativeMouse")
-                
                 if steps <= 1:
-                    mousex_property.SetValue(_mouse_report, _System.Int16(dx))
-                    mousey_property.SetValue(_mouse_report, _System.Int16(dy))
-                    args = _System.Array[_System.Object]([_mouse_report])
-                    update_method.Invoke(_faker_input, args)
+                    _fi_send_mouse_move(dx, dy, _CACHE_RANGE)
                     return
-                
+
                 step_x = dx / steps
                 step_y = dy / steps
-                
+
                 for i in range(steps):
                     start_time = time.perf_counter()
-                    
+
                     if i == steps - 1:
                         final_x = dx - int(step_x * i)
                         final_y = dy - int(step_y * i)
-                        mousex_property.SetValue(_mouse_report, _System.Int16(final_x))
-                        mousey_property.SetValue(_mouse_report, _System.Int16(final_y))
+                        _fi_send_mouse_move(final_x, final_y, _CACHE_RANGE)
                     else:
-                        mousex_property.SetValue(_mouse_report, _System.Int16(int(step_x)))
-                        mousey_property.SetValue(_mouse_report, _System.Int16(int(step_y)))
-                    
-                    args = _System.Array[_System.Object]([_mouse_report])
-                    update_method.Invoke(_faker_input, args)
-                    
+                        _fi_send_mouse_move(int(step_x), int(step_y), _CACHE_RANGE)
+
                     if step_speed > 0:
                         elapsed_time = time.perf_counter() - start_time
                         remaining_time = max(0, step_speed_seconds - elapsed_time)
@@ -146,26 +83,21 @@ def smooth_move_mouse(dx: int, dy: int, step_delay: float = 0.01, steps: int = N
                         remaining_time = max(0, step_delay - elapsed_time)
                         if remaining_time > 0:
                             time.sleep(remaining_time)
-                
+
                 if second_dy is not None and recenter_delay is not None:
                     if recenter_delay > 0:
                         time.sleep(recenter_delay)
-                        
+
                     step_dy = second_dy // steps
                     for i in range(steps):
                         start_time = time.perf_counter()
-                        
+
                         if i == steps - 1:
                             final_y = second_dy - (step_dy * i)
-                            mousex_property.SetValue(_mouse_report, _System.Int16(0))
-                            mousey_property.SetValue(_mouse_report, _System.Int16(final_y))
+                            _fi_send_mouse_move(0, final_y, _CACHE_RANGE)
                         else:
-                            mousex_property.SetValue(_mouse_report, _System.Int16(0))
-                            mousey_property.SetValue(_mouse_report, _System.Int16(step_dy))
-                        
-                        args = _System.Array[_System.Object]([_mouse_report])
-                        update_method.Invoke(_faker_input, args)
-                        
+                            _fi_send_mouse_move(0, step_dy, _CACHE_RANGE)
+
                         if step_speed > 0:
                             elapsed_time = time.perf_counter() - start_time
                             remaining_time = max(0, step_speed_seconds - elapsed_time)
@@ -176,44 +108,21 @@ def smooth_move_mouse(dx: int, dy: int, step_delay: float = 0.01, steps: int = N
                             remaining_time = max(0, step_delay - elapsed_time)
                             if remaining_time > 0:
                                 time.sleep(remaining_time)
-                                
+
             except Exception as e:
                 print(f"Mouse movement error: {e}")
 
     if _current_movement_thread and _current_movement_thread.is_alive():
         _current_movement_thread.join(timeout=0.1)
-    
+
     _current_movement_thread = threading.Thread(target=move, daemon=True)
     _current_movement_thread.start()
 
+
 def mouse_scroll(amount: int):
-    """Scroll mouse wheel"""
-    if not _initialized and not initialize_fakerinput():
-        return False
-    
-    try:
-        wheel_property = _RelativeMouseReportType.GetProperty("WheelPosition")
-        update_method = _FakerInputType.GetMethod("UpdateRelativeMouse")
-        
-        # Clamp the value to the signed byte range first
-        wheel_value = max(-127, min(127, amount))
-        
-        # Convert the signed value to its unsigned 8-bit equivalent if it's negative
-        if wheel_value < 0:
-            wheel_value += 256  # e.g., -1 becomes 255, -120 becomes 136
-        
-        # Set the value using the correct System.Byte type
-        wheel_property.SetValue(_mouse_report, _System.Byte(wheel_value))
-        
-        args = _System.Array[_System.Object]([_mouse_report])
-        update_method.Invoke(_faker_input, args)
-        
-        # Reset wheel position back to 0 using the correct type
-        wheel_property.SetValue(_mouse_report, _System.Byte(0))
-        return True
-    except Exception as e:
-        print(f"Mouse scroll error: {e}")
-        return False
+    """Scroll mouse wheel via shared FakerInput."""
+    return _fi_send_mouse_scroll(amount, _CACHE_RANGE)
+
 
 # Core mouse button functions
 def left_mouse_down():


### PR DESCRIPTION
## Summary
- `mouse.py` and `mouse_passthrough/faker_input.py` each created their own FakerInput driver connection. The driver only supports one active connection, so the passthrough module's connection won and `mouse.py`'s was dead — causing recentering, turning, and click/scroll commands to silently fail.
- Refactored `mouse.py` to delegate all FakerInput calls to the shared connection in `mouse_passthrough/faker_input.py`
- Added `send_mouse_button()`, `send_mouse_scroll()`, and `is_initialized()` to the shared `faker_input.py` module

## Test plan
- [ ] Launch FA11y — mouse passthrough should auto-start as before
- [ ] Test recentering (middle mouse / Num5) — should now move the camera
- [ ] Test turning (numpad arrows) — should work
- [ ] Test mouse passthrough — physical mouse movements should still relay to the game
- [ ] Test toggle passthrough (Alt+Shift+P) — should disable/enable
- [ ] Test Spectre integration — should continue working as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)