### PR TITLE
Add --benchmark and --profile performance profiling modes

### DIFF
--- a/FA11y.py
+++ b/FA11y.py
@@ -254,6 +254,13 @@ def signal_handler(signum, frame):
     except:
         pass  # Ignore cleanup errors during shutdown
 
+    # Save profiling data before hard exit (os._exit skips atexit handlers)
+    try:
+        from lib.utilities import perf_profiler
+        perf_profiler.save_profile_results()
+    except Exception:
+        pass
+
     print("FA11y is closing...")
     # Force immediate exit
     os._exit(0)
@@ -2506,9 +2513,90 @@ def main() -> None:
         except:
             pass  # Ignore cleanup errors during shutdown
 
+        # Save profiling data before hard exit (os._exit skips atexit handlers)
+        try:
+            from lib.utilities import perf_profiler
+            perf_profiler.save_profile_results()
+        except Exception:
+            pass
+
         print("FA11y is closing...")
         # Use os._exit for immediate termination
         os._exit(0)
 
 if __name__ == "__main__":
-    main()
+    if "--profile" in sys.argv:
+        # Profile mode: run FA11y normally with real-time per-function profiling
+        from lib.utilities import perf_profiler
+
+        interval = 15.0
+        output_file = "profile_results.txt"
+        for i, arg in enumerate(sys.argv):
+            if arg == "--interval" and i + 1 < len(sys.argv):
+                interval = float(sys.argv[i + 1])
+            if arg == "--output" and i + 1 < len(sys.argv):
+                output_file = sys.argv[i + 1]
+
+        perf_profiler.enable_profile(output_file=output_file, interval=interval)
+        perf_profiler.install_profile_hooks()
+
+        # Now run FA11y normally — profiling wraps are in place.
+        # Wrap in try/finally as an extra safety net for saving profile data,
+        # since os._exit() in signal_handler or main() skips atexit handlers.
+        try:
+            main()
+        except (KeyboardInterrupt, SystemExit):
+            pass
+        finally:
+            perf_profiler.save_profile_results()
+
+    elif "--benchmark" in sys.argv:
+        # Benchmark mode: run the navigation pipeline with profiling
+        from lib.utilities import perf_profiler
+
+        runs = 1
+        for i, arg in enumerate(sys.argv):
+            if arg == "--runs" and i + 1 < len(sys.argv):
+                runs = int(sys.argv[i + 1])
+
+        output_file = "benchmark_results.txt"
+        for i, arg in enumerate(sys.argv):
+            if arg == "--output" and i + 1 < len(sys.argv):
+                output_file = sys.argv[i + 1]
+
+        perf_profiler.enable(output_file)
+
+        print(f"FA11y Benchmark Mode: {runs} run(s), output -> {output_file}")
+        print("Initializing...")
+
+        # Minimal init: just enough to run the navigation pipeline
+        from lib.utilities.utilities import read_config, get_config_boolean
+        from lib.detection.player_position import start_icon_detection
+
+        def check_for_pixel():
+            """Reuse the same logic FA11y uses to decide PPI vs icon detection."""
+            try:
+                from lib.managers.screenshot_manager import get_pixel
+                pixel = get_pixel(1883, 49)
+                if pixel is None:
+                    return True
+                r, g, b = pixel
+                return (250 <= r <= 255) and (250 <= g <= 255) and (250 <= b <= 255)
+            except Exception:
+                return True
+
+        for i in range(runs):
+            label = f"Run {i+1}/{runs}"
+            print(f"\n[{label}] Running navigation pipeline...")
+            perf_profiler.start_run(label)
+            try:
+                start_icon_detection(use_ppi=check_for_pixel())
+            except Exception as e:
+                perf_profiler.mark(f"ERROR: {e}")
+                perf_profiler.end_run()
+                print(f"  Error: {e}")
+
+        perf_profiler.save_results()
+        print("\nBenchmark complete.")
+    else:
+        main()

--- a/lib/utilities/perf_profiler.py
+++ b/lib/utilities/perf_profiler.py
@@ -1,0 +1,717 @@
+"""
+Performance profiler for FA11y.
+
+Two modes:
+  --benchmark   One-shot navigation pipeline benchmark (save to txt)
+  --profile     Real-time per-function profiling across ALL modules (live + save)
+
+Usage:
+    python FA11y.py --benchmark              # Single navigation cycle
+    python FA11y.py --benchmark --runs 5     # 5 cycles
+    python FA11y.py --profile                # Normal FA11y with live profiling
+    python FA11y.py --profile --interval 10  # Print summary every 10s (default 15)
+
+All profiling is zero-cost when neither flag is passed.
+"""
+import time
+import os
+import sys
+import atexit
+import threading
+import functools
+import statistics
+from datetime import datetime
+from typing import Optional, List, Dict, Callable
+from collections import defaultdict
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Shared state
+# ═══════════════════════════════════════════════════════════════════════
+
+_enabled = False        # True for --benchmark mode
+_profile_enabled = False  # True for --profile mode
+_output_file = "benchmark_results.txt"
+_profile_file = "profile_results.txt"
+
+# ── Benchmark (--benchmark) state ────────────────────────────────────
+_current_run: Optional[Dict] = None
+_all_runs: List[Dict] = []
+_lock = threading.Lock()
+
+# ── Profile (--profile) state ────────────────────────────────────────
+_func_stats: Dict[str, List[float]] = defaultdict(list)  # name -> [durations_ms]
+_func_stats_lock = threading.Lock()
+_profile_start_time: Optional[float] = None
+_profile_interval = 15.0  # seconds between live summary prints
+_profile_timer: Optional[threading.Timer] = None
+_call_counts_since_print: Dict[str, int] = defaultdict(int)
+
+
+def enable(output_file: str = "benchmark_results.txt"):
+    """Enable --benchmark mode."""
+    global _enabled, _output_file
+    _enabled = True
+    _output_file = output_file
+
+
+def enable_profile(output_file: str = "profile_results.txt", interval: float = 15.0):
+    """Enable --profile mode with live periodic summaries."""
+    global _profile_enabled, _profile_file, _profile_interval, _profile_start_time
+    _profile_enabled = True
+    _profile_file = output_file
+    _profile_interval = interval
+    _profile_start_time = time.perf_counter()
+    _schedule_profile_print()
+    atexit.register(save_profile_results)
+    print(f"[PROFILE] Live profiling enabled. Summary every {interval:.0f}s. Output -> {output_file}")
+
+
+def is_enabled() -> bool:
+    return _enabled
+
+
+def is_profile_enabled() -> bool:
+    return _profile_enabled
+
+
+def start_run(label: str = ""):
+    """Begin a new profiling run (one full navigation cycle)."""
+    global _current_run
+    if not _enabled:
+        return
+    with _lock:
+        _current_run = {
+            "label": label,
+            "start": time.perf_counter(),
+            "steps": [],
+            "end": None,
+        }
+
+
+def mark(step_name: str):
+    """Record a named timestamp within the current run."""
+    if not _enabled or _current_run is None:
+        return
+    with _lock:
+        _current_run["steps"].append((step_name, time.perf_counter()))
+
+
+def end_run():
+    """Finish the current run and store it."""
+    global _current_run
+    if not _enabled or _current_run is None:
+        return
+    with _lock:
+        _current_run["end"] = time.perf_counter()
+        _all_runs.append(_current_run)
+        _current_run = None
+
+
+def save_results():
+    """Write all collected runs to the output file."""
+    if not _enabled or not _all_runs:
+        return
+
+    lines = []
+    lines.append("=" * 80)
+    lines.append(f"  FA11y Navigation Pipeline Benchmark")
+    lines.append(f"  Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"  Runs: {len(_all_runs)}")
+    lines.append("=" * 80)
+
+    # Per-run breakdown
+    for i, run in enumerate(_all_runs):
+        run_start = run["start"]
+        run_end = run["end"] or run_start
+        total_ms = (run_end - run_start) * 1000
+        label = run["label"] or f"Run {i+1}"
+
+        lines.append(f"\n--- {label} (total: {total_ms:.1f}ms) ---")
+        lines.append(f"  {'Step':<45} {'Elapsed':>8}  {'Cumulative':>10}")
+        lines.append(f"  {'-'*65}")
+
+        prev_t = run_start
+        for step_name, step_t in run["steps"]:
+            delta_ms = (step_t - prev_t) * 1000
+            cumul_ms = (step_t - run_start) * 1000
+            lines.append(f"  {step_name:<45} {delta_ms:>7.2f}ms  {cumul_ms:>9.2f}ms")
+            prev_t = step_t
+
+        # Final delta to end
+        if run["end"] and run["steps"]:
+            last_step_t = run["steps"][-1][1]
+            final_delta = (run["end"] - last_step_t) * 1000
+            lines.append(f"  {'(end of run)':<45} {final_delta:>7.2f}ms  {total_ms:>9.2f}ms")
+
+    # Summary across runs
+    if len(_all_runs) > 1:
+        lines.append(f"\n{'=' * 80}")
+        lines.append(f"  SUMMARY ACROSS {len(_all_runs)} RUNS")
+        lines.append(f"{'=' * 80}")
+
+        totals = [(r["end"] - r["start"]) * 1000 for r in _all_runs if r["end"]]
+        if totals:
+            import statistics
+            lines.append(f"  Total time:  min={min(totals):.1f}ms  avg={statistics.mean(totals):.1f}ms  max={max(totals):.1f}ms")
+            if len(totals) > 1:
+                lines.append(f"               stdev={statistics.stdev(totals):.1f}ms")
+
+        # Per-step averages
+        step_names = []
+        if _all_runs[0]["steps"]:
+            step_names = [s[0] for s in _all_runs[0]["steps"]]
+
+        if step_names:
+            lines.append(f"\n  {'Step':<45} {'Avg':>8}  {'Min':>8}  {'Max':>8}")
+            lines.append(f"  {'-'*75}")
+
+            for sname in step_names:
+                deltas = []
+                for run in _all_runs:
+                    steps = run["steps"]
+                    for j, (name, t) in enumerate(steps):
+                        if name == sname:
+                            prev = run["start"] if j == 0 else steps[j-1][1]
+                            deltas.append((t - prev) * 1000)
+                            break
+                if deltas:
+                    avg = statistics.mean(deltas)
+                    mn = min(deltas)
+                    mx = max(deltas)
+                    lines.append(f"  {sname:<45} {avg:>7.2f}ms  {mn:>7.2f}ms  {mx:>7.2f}ms")
+
+    text = "\n".join(lines) + "\n"
+
+    with open(_output_file, "w", encoding="utf-8") as f:
+        f.write(text)
+
+    print(f"\nBenchmark results saved to: {os.path.abspath(_output_file)}")
+    print(text)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  --profile mode: per-function decorator and live summaries
+# ═══════════════════════════════════════════════════════════════════════
+
+def profile_func(name: Optional[str] = None):
+    """Decorator that records per-call timing when --profile is active.
+
+    Usage:
+        @profile_func()                     # auto-names as "module.func"
+        @profile_func("ppi.find_position")  # explicit name
+        def my_function(...):
+            ...
+
+    Zero overhead when profiling is disabled — the decorator returns
+    the original function unwrapped at decoration time.
+    """
+    def decorator(fn: Callable) -> Callable:
+        # Early exit: if profile isn't enabled at import time, return unwrapped.
+        # Functions decorated before enable_profile() is called will NOT be tracked.
+        # That's fine — we re-decorate after enable_profile() in the module hooks.
+        if not _profile_enabled:
+            # Store the label so we can re-wrap later
+            fn._profile_name = name or f"{fn.__module__}.{fn.__qualname__}"
+            return fn
+
+        label = name or f"{fn.__module__}.{fn.__qualname__}"
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            t0 = time.perf_counter()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                elapsed_ms = (time.perf_counter() - t0) * 1000
+                with _func_stats_lock:
+                    _func_stats[label].append(elapsed_ms)
+                    _call_counts_since_print[label] += 1
+        return wrapper
+    return decorator
+
+
+def record_call(name: str, elapsed_ms: float):
+    """Manually record a function call timing (for cases where decorator doesn't fit)."""
+    if not _profile_enabled:
+        return
+    with _func_stats_lock:
+        _func_stats[name].append(elapsed_ms)
+        _call_counts_since_print[name] += 1
+
+
+def wrap_function(fn: Callable, name: Optional[str] = None) -> Callable:
+    """Wrap an existing function with profiling. Use when you can't use the decorator.
+
+    Returns the original function if profiling is disabled.
+    """
+    if not _profile_enabled:
+        return fn
+
+    label = name or f"{fn.__module__}.{fn.__qualname__}"
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        t0 = time.perf_counter()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            with _func_stats_lock:
+                _func_stats[label].append(elapsed_ms)
+                _call_counts_since_print[label] += 1
+    return wrapper
+
+
+def _schedule_profile_print():
+    """Schedule the next periodic summary print."""
+    global _profile_timer
+    if not _profile_enabled:
+        return
+    _profile_timer = threading.Timer(_profile_interval, _print_profile_summary)
+    _profile_timer.daemon = True
+    _profile_timer.start()
+
+
+def _print_profile_summary():
+    """Print a live summary of profiled function calls since last print."""
+    if not _profile_enabled:
+        return
+
+    with _func_stats_lock:
+        if not _call_counts_since_print:
+            _schedule_profile_print()
+            return
+
+        elapsed_total = time.perf_counter() - _profile_start_time
+        lines = []
+        lines.append(f"\n[PROFILE] Live summary @ {elapsed_total:.0f}s uptime")
+        lines.append(f"  {'Function':<50} {'Calls':>6} {'Avg':>8} {'Min':>8} {'Max':>8} {'Total':>9}")
+        lines.append(f"  {'-'*95}")
+
+        # Sort by total time descending
+        entries = []
+        for fname, count in _call_counts_since_print.items():
+            all_times = _func_stats[fname]
+            recent = all_times[-count:] if count <= len(all_times) else all_times
+            if recent:
+                entries.append((fname, count, recent))
+
+        entries.sort(key=lambda e: sum(e[2]), reverse=True)
+
+        for fname, count, recent in entries:
+            avg = statistics.mean(recent)
+            mn = min(recent)
+            mx = max(recent)
+            total = sum(recent)
+            lines.append(f"  {fname:<50} {count:>6} {avg:>7.2f}ms {mn:>7.2f}ms {mx:>7.2f}ms {total:>8.1f}ms")
+
+        # Reset recent counts
+        _call_counts_since_print.clear()
+
+    print("\n".join(lines))
+
+    # Save full results to disk each interval so data survives crashes / os._exit()
+    save_profile_results()
+
+    _schedule_profile_print()
+
+
+def save_profile_results():
+    """Write final profile summary to file. Called from signal handler and finally blocks.
+
+    Must be safe to call from a signal handler context — no locks that could deadlock,
+    minimal allocations, flush+sync to survive os._exit() immediately after.
+    """
+    if not _profile_enabled:
+        return
+
+    # Cancel pending timer
+    global _profile_timer
+    try:
+        if _profile_timer:
+            _profile_timer.cancel()
+    except Exception:
+        pass
+
+    try:
+        elapsed_total = time.perf_counter() - (_profile_start_time or time.perf_counter())
+        lines = []
+        lines.append("=" * 100)
+        lines.append(f"  FA11y Real-Time Profile Results")
+        lines.append(f"  Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"  Session duration: {elapsed_total:.1f}s")
+        lines.append("=" * 100)
+
+        # Copy stats without holding the lock long (signal handler safety)
+        stats_copy = dict(_func_stats)
+
+        if stats_copy:
+            lines.append(f"\n  {'Function':<50} {'Calls':>6} {'Avg':>8} {'Min':>8} {'Max':>8} {'Total':>9} {'%':>6}")
+            lines.append(f"  {'-'*100}")
+
+            grand_total = sum(sum(times) for times in stats_copy.values())
+
+            entries = sorted(stats_copy.items(), key=lambda e: sum(e[1]), reverse=True)
+
+            for fname, times in entries:
+                count = len(times)
+                avg = sum(times) / count
+                mn = min(times)
+                mx = max(times)
+                total = sum(times)
+                pct = (total / grand_total * 100) if grand_total > 0 else 0
+                lines.append(f"  {fname:<50} {count:>6} {avg:>7.2f}ms {mn:>7.2f}ms {mx:>7.2f}ms {total:>8.1f}ms {pct:>5.1f}%")
+
+            lines.append(f"\n  Grand total profiled time: {grand_total:.1f}ms")
+        else:
+            lines.append("\n  (No profiled function calls recorded)")
+
+        lines.append(f"  Session wall time: {elapsed_total*1000:.1f}ms")
+
+        text = "\n".join(lines) + "\n"
+
+        # Write with explicit flush + fsync to ensure data hits disk before os._exit()
+        with open(_profile_file, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+
+        print(f"\n[PROFILE] Results saved to: {os.path.abspath(_profile_file)}")
+        print(text)
+    except Exception as e:
+        # Last resort: try to at least print to console
+        try:
+            print(f"\n[PROFILE] Could not save results: {e}")
+        except Exception:
+            pass
+
+
+def _hook(target, attr, name):
+    """Safely wrap target.attr with profiling under the given name."""
+    fn = getattr(target, attr, None)
+    if fn is not None:
+        setattr(target, attr, wrap_function(fn, name))
+        return True
+    return False
+
+
+def install_profile_hooks():
+    """Wrap functions across ALL FA11y modules with profiling.
+
+    Called once after enable_profile() so that all wrapping happens
+    while _profile_enabled is True.
+    """
+    if not _profile_enabled:
+        return
+
+    hooked = 0
+
+    # ── PPI ─────────────────────────────────────────────────────────
+    try:
+        from lib.detection import ppi
+        for fn in ['find_player_position', 'find_best_match', 'capture_map_screen', '_match_at_scale']:
+            hooked += _hook(ppi, fn, f"ppi.{fn}")
+    except Exception as e:
+        print(f"[PROFILE] ppi: {e}")
+
+    # ── Player position ─────────────────────────────────────────────
+    try:
+        from lib.detection import player_position as pp
+        for fn in [
+            'start_icon_detection', 'icon_detection_cycle', 'get_player_info_ppi',
+            'get_player_info', 'find_minimap_icon_direction', 'find_player_icon_location',
+            'find_player_icon_location_with_direction', 'handle_poi_selection',
+            'play_spatial_poi_sound', 'perform_poi_actions', 'process_screenshot',
+            'auto_turn_towards_poi', 'calculate_poi_info', 'generate_poi_message',
+            'speak_auto_turn_result', 'check_for_minimap', 'check_for_full_map',
+            'handle_closed_map_ppi', 'speak_minimap_direction', 'find_triangle_tip',
+            'get_position_with_fallback',
+        ]:
+            hooked += _hook(pp, fn, f"player_pos.{fn}")
+        # Position tracker methods
+        if hasattr(pp, 'position_tracker') and pp.position_tracker:
+            for fn in ['get_position_and_angle', 'start_monitoring', 'stop_monitoring', '_monitor_loop']:
+                hooked += _hook(pp.position_tracker, fn, f"pos_tracker.{fn}")
+    except Exception as e:
+        print(f"[PROFILE] player_position: {e}")
+
+    # ── Screenshot manager ──────────────────────────────────────────
+    try:
+        from lib.managers import screenshot_manager as sm
+        mgr = sm.screenshot_manager
+        for fn in ['capture_region', 'get_pixel', 'capture_full_screen', 'capture_coordinates']:
+            hooked += _hook(mgr, fn, f"screenshot.{fn}")
+    except Exception as e:
+        print(f"[PROFILE] screenshot_manager: {e}")
+
+    # ── Match tracker ───────────────────────────────────────────────
+    try:
+        from lib.detection import match_tracker as mt
+        tracker = mt.match_tracker
+        for fn in [
+            '_monitor_loop', '_update_player_position', '_check_nearby_game_objects',
+            '_check_height_indicator_transition', '_start_new_match', '_mark_object_visited',
+            'get_position_update_interval',
+        ]:
+            hooked += _hook(tracker, fn, f"match_tracker.{fn}")
+    except Exception as e:
+        print(f"[PROFILE] match_tracker: {e}")
+
+    # ── Spatial audio ───────────────────────────────────────────────
+    try:
+        from lib.utilities.spatial_audio import SpatialAudio
+        for fn in ['play_audio', 'stop', 'calculate_distance_and_angle', 'get_volume_from_config']:
+            hooked += _hook(SpatialAudio, fn, f"spatial_audio.{fn}")
+    except Exception as e:
+        print(f"[PROFILE] spatial_audio: {e}")
+
+    # ── Audio engine ────────────────────────────────────────────────
+    try:
+        from lib.audio import get_engine
+        engine = get_engine()
+        if engine:
+            for fn in ['play_sound', 'stop_sound', 'is_sound_playing']:
+                hooked += _hook(engine, fn, f"audio_engine.{fn}")
+    except Exception:
+        pass  # Engine may not be initialized yet
+
+    # ── Config reads/writes ─────────────────────────────────────────
+    try:
+        from lib.utilities import utilities as util
+        for fn in ['read_config', 'save_config']:
+            hooked += _hook(util, fn, f"config.{fn}")
+    except Exception as e:
+        print(f"[PROFILE] utilities: {e}")
+
+    # ── Config manager ──────────────────────────────────────────────
+    try:
+        from lib.config.config_manager import config_manager as cm
+        for fn in ['get', 'set', 'reload']:
+            hooked += _hook(cm, fn, f"config_mgr.{fn}")
+    except Exception:
+        pass
+
+    # ── Dynamic object finder ───────────────────────────────────────
+    try:
+        from lib.detection import dynamic_object_finder as dof
+        finder = getattr(dof, 'optimized_finder', None)
+        if finder:
+            for fn in ['fast_multi_scale_match', 'batch_detect_dynamic_objects', 'detect_dynamic_object']:
+                hooked += _hook(finder, fn, f"dynamic_obj.{fn}")
+    except Exception:
+        pass
+
+    # ── Height monitor ──────────────────────────────────────────────
+    try:
+        from lib.monitors import height_monitor as hm
+        for fn in ['is_height_indicator_visible', 'check_height', 'start_height_monitor']:
+            hooked += _hook(hm, fn, f"height_mon.{fn}")
+    except Exception:
+        pass
+
+    # ── Background monitor ──────────────────────────────────────────
+    try:
+        from lib.monitors import background_monitor as bm
+        mon = getattr(bm, 'monitor', None)
+        if mon:
+            for fn in ['check_map_status', 'check_inventory_status', 'monitor_loop']:
+                hooked += _hook(mon, fn, f"bg_monitor.{fn}")
+    except Exception:
+        pass
+
+    # ── Storm monitor ───────────────────────────────────────────────
+    try:
+        from lib.monitors import storm_monitor as stm
+        smon = getattr(stm, 'storm_monitor', None)
+        if smon:
+            for fn in ['detection_loop', 'detect_purple_tint', 'detect_storm_on_minimap']:
+                hooked += _hook(smon, fn, f"storm_mon.{fn}")
+    except Exception:
+        pass
+
+    # ── Bloom monitor ───────────────────────────────────────────────
+    try:
+        from lib.monitors import bloom_monitor as blm
+        bmon = getattr(blm, 'bloom_monitor', None)
+        if bmon:
+            for fn in ['_monitor_loop', '_detect_bloom', '_is_center_crosshair', '_play_bloom_tone']:
+                hooked += _hook(bmon, fn, f"bloom_mon.{fn}")
+    except Exception:
+        pass
+
+    # ── Material monitor ────────────────────────────────────────────
+    try:
+        from lib.monitors import material_monitor as mm
+        mmon = getattr(mm, 'material_monitor', None)
+        if mmon:
+            for fn in ['monitor_loop', 'detect_material', 'detect_count']:
+                hooked += _hook(mmon, fn, f"material_mon.{fn}")
+    except Exception:
+        pass
+
+    # ── Resource monitor ────────────────────────────────────────────
+    try:
+        from lib.monitors import resource_monitor as rm
+        rmon = getattr(rm, 'resource_monitor', None)
+        if rmon:
+            for fn in ['monitor_loop', 'detect_resource', 'detect_count']:
+                hooked += _hook(rmon, fn, f"resource_mon.{fn}")
+    except Exception:
+        pass
+
+    # ── Dynamic object monitor ──────────────────────────────────────
+    try:
+        from lib.monitors import dynamic_object_monitor as dom
+        dmon = getattr(dom, 'dynamic_object_monitor', None)
+        if dmon:
+            for fn in ['detection_loop', '_play_spatial_audio']:
+                hooked += _hook(dmon, fn, f"dynobj_mon.{fn}")
+    except Exception:
+        pass
+
+    # ── Hotbar manager ──────────────────────────────────────────────
+    try:
+        from lib.managers import hotbar_manager as hb
+        for fn in [
+            'detect_hotbar_item', 'detect_hotbar_item_thread', 'check_slot',
+            'detect_rarity_for_slot', 'detect_rarity_by_color', '_ocr_detect_item_name',
+            'announce_ammo', 'announce_ammo_manually', 'announce_attachments',
+            'detect_ammo', 'detect_ammo_count',
+        ]:
+            hooked += _hook(hb, fn, f"hotbar.{fn}")
+    except Exception:
+        pass
+
+    # ── OCR manager ─────────────────────────────────────────────────
+    try:
+        from lib.managers import ocr_manager as om
+        mgr = getattr(om, 'ocr_manager', None) or getattr(om, 'OCRManager', None)
+        if mgr and not isinstance(mgr, type):
+            for fn in ['read_numbers', 'read_text']:
+                hooked += _hook(mgr, fn, f"ocr.{fn}")
+    except Exception:
+        pass
+
+    # ── Game object manager ─────────────────────────────────────────
+    try:
+        from lib.managers import game_object_manager as gom
+        mgr = getattr(gom, 'game_object_manager', None)
+        if mgr:
+            for fn in [
+                'get_game_objects_for_map', 'find_nearest_unvisited_object_of_type',
+                'load_game_objects',
+            ]:
+                hooked += _hook(mgr, fn, f"game_obj.{fn}")
+    except Exception:
+        pass
+
+    # ── POI data manager ────────────────────────────────────────────
+    try:
+        from lib.managers import poi_data_manager as pdm
+        for fn in ['get_poi_data', 'get_current_map']:
+            hooked += _hook(pdm, fn, f"poi_data.{fn}")
+        # FavoritesManager
+        fmgr = getattr(pdm, 'favorites_manager', None)
+        if fmgr:
+            for fn in ['add_favorite', 'remove_favorite', 'is_favorite', 'get_favorites']:
+                hooked += _hook(fmgr, fn, f"favorites.{fn}")
+    except Exception:
+        pass
+
+    # ── Custom POI manager ──────────────────────────────────────────
+    try:
+        from lib.managers import custom_poi_manager as cpm
+        for fn in ['update_poi_handler', 'get_custom_pois', 'save_custom_poi']:
+            hooked += _hook(cpm, fn, f"custom_poi.{fn}")
+    except Exception:
+        pass
+
+    # ── Lobby reader ────────────────────────────────────────────────
+    try:
+        from lib.detection import lobby_reader as lr
+        for fn in [
+            'detect_screen_type', 'read_build_mode', 'find_layout',
+            'read_ranked_state', 'read_fill_state', 'toggle_lobby_fill',
+            'set_team_size', 'toggle_ranked', 'toggle_build_mode',
+        ]:
+            hooked += _hook(lr, fn, f"lobby.{fn}")
+    except Exception:
+        pass
+
+    # ── Exit match ──────────────────────────────────────────────────
+    try:
+        from lib.detection import exit_match as em
+        for fn in ['exit_match', 'check_pixel_color']:
+            hooked += _hook(em, fn, f"exit_match.{fn}")
+    except Exception:
+        pass
+
+    # ── HSR (health/shield/rarity) ──────────────────────────────────
+    try:
+        from lib.detection import hsr
+        for fn in ['check_health_shields', 'check_rarity']:
+            hooked += _hook(hsr, fn, f"hsr.{fn}")
+    except Exception:
+        pass
+
+    # ── Mouse utilities ─────────────────────────────────────────────
+    try:
+        from lib.utilities import mouse as mu
+        for fn in ['move_to', 'move_to_and_click', 'move_to_and_right_click', 'click_mouse', 'smooth_move_mouse']:
+            hooked += _hook(mu, fn, f"mouse.{fn}")
+    except Exception:
+        pass
+
+    # ── Mouse passthrough service ───────────────────────────────────
+    try:
+        from lib.mouse_passthrough import get_mouse_passthrough
+        svc = get_mouse_passthrough()
+        if svc:
+            for fn in ['toggle', 'recapture_mouse', 'update_dpi']:
+                hooked += _hook(svc, fn, f"mouse_pt.{fn}")
+    except Exception:
+        pass
+
+    # ── Input utilities ─────────────────────────────────────────────
+    try:
+        from lib.utilities import input as inp
+        for fn in ['is_key_pressed', 'is_key_combination_pressed', 'parse_key_combination']:
+            hooked += _hook(inp, fn, f"input.{fn}")
+    except Exception:
+        pass
+
+    # ── Epic auth ───────────────────────────────────────────────────
+    try:
+        from lib.utilities import epic_auth as ea
+        auth = getattr(ea, 'epic_auth', None)
+        if auth:
+            for fn in [
+                'query_locker_items', 'get_equipped_cosmetics', 'get_saved_loadouts',
+                'fetch_owned_cosmetics', 'fetch_cosmetics_from_api',
+            ]:
+                hooked += _hook(auth, fn, f"epic_auth.{fn}")
+        locker = getattr(ea, 'locker_api', None)
+        if locker:
+            for fn in ['equip_cosmetic', 'save_loadout', 'load_loadout']:
+                hooked += _hook(locker, fn, f"locker_api.{fn}")
+    except Exception:
+        pass
+
+    # ── Social / Discovery ──────────────────────────────────────────
+    try:
+        from lib.managers import social_manager as socm
+        mgr = getattr(socm, 'social_manager', None)
+        if mgr:
+            for fn in ['get_friends_list', 'get_party_members']:
+                hooked += _hook(mgr, fn, f"social.{fn}")
+    except Exception:
+        pass
+
+    try:
+        from lib.utilities import epic_discovery as ed
+        for fn in ['search_islands', 'lookup_island_code', 'get_creator_islands']:
+            hooked += _hook(ed, fn, f"discovery.{fn}")
+    except Exception:
+        pass
+
+    print(f"[PROFILE] {hooked} function hooks installed across all modules.")

--- a/tests/benchmark_approaches.py
+++ b/tests/benchmark_approaches.py
@@ -1,0 +1,296 @@
+"""Benchmark every PPI approach we can think of."""
+import cv2
+import numpy as np
+import time
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+img = cv2.imread('maps/main.png', cv2.IMREAD_GRAYSCALE)
+h, w = img.shape
+crop = img[200:450, 300:550].copy()
+snow_crop = img[50:300, w//2-125:w//2+125].copy()
+
+N = 50  # iterations per benchmark
+
+
+def run_match(setup_fn, match_fn, label, notes=""):
+    ctx = setup_fn()
+    # Warm up
+    match_fn(crop, ctx)
+    match_fn(snow_crop, ctx)
+    # Time
+    t0 = time.perf_counter()
+    for _ in range(N):
+        match_fn(crop, ctx)
+    ms = (time.perf_counter() - t0) / N * 1000
+    fn = "OK" if match_fn(crop, ctx) is not None else "FAIL"
+    fs = "OK" if match_fn(snow_crop, ctx) is not None else "FAIL"
+    print(f"  {label:<45} {ms:>6.1f}ms  {fn:<6} {fs:<6} {notes}")
+    return ms, fn, fs
+
+
+def do_homography(kp1, kp_map, good, capture_shape):
+    if len(good) <= 25:
+        return None
+    src = np.float32([kp1[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+    dst = np.float32([kp_map[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    M, _ = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
+    if M is None or not np.all(np.isfinite(M)):
+        return None
+    ch, cw = capture_shape
+    pts = np.float32([[0, 0], [0, ch-1], [cw-1, ch-1], [cw-1, 0]]).reshape(-1, 1, 2)
+    tp = cv2.perspectiveTransform(pts, M)
+    return tp if np.all(np.isfinite(tp)) else None
+
+
+def ratio_test(matches, ratio=0.75):
+    good = []
+    for pair in matches:
+        if len(pair) == 2:
+            m, n = pair
+            if m.distance < ratio * n.distance:
+                good.append(m)
+    return good
+
+
+print(f"\n{'='*90}")
+print(f"  PPI APPROACH BENCHMARK  ({w}x{h} map, 250x250 captures, {N} iterations)")
+print(f"{'='*90}")
+print(f"  {'Approach':<45} {'Time':>6}    {'Norm':<6} {'Snow':<6} Notes")
+print(f"  {'-'*85}")
+
+# ── 1. CURRENT: SIFT + BFMatcher ──────────────────────────────────────
+def setup_current():
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(contrastThreshold=0.03)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift_map.detectAndCompute(img, None)
+    return {'sift': sift_cap, 'bf': bf, 'kp': kp, 'des': des}
+
+def match_current(capture, ctx):
+    kp1, des1 = ctx['sift'].detectAndCompute(capture, None)
+    if des1 is None: return None
+    matches = ctx['bf'].knnMatch(des1, ctx['des'], k=2)
+    return do_homography(kp1, ctx['kp'], ratio_test(matches), capture.shape)
+
+run_match(setup_current, match_current, "1. Current (SIFT+BF, ct=0.03)")
+
+# ── 2. SIFT + FLANN ───────────────────────────────────────────────────
+def setup_flann():
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(contrastThreshold=0.03)
+    ip = dict(algorithm=1, trees=5)
+    sp = dict(checks=50)
+    flann = cv2.FlannBasedMatcher(ip, sp)
+    kp, des = sift_map.detectAndCompute(img, None)
+    # Warm FLANN index
+    dummy = np.random.rand(10, 128).astype(np.float32)
+    try: flann.knnMatch(dummy, des, k=2)
+    except: pass
+    return {'sift': sift_cap, 'flann': flann, 'kp': kp, 'des': des}
+
+def match_flann(capture, ctx):
+    kp1, des1 = ctx['sift'].detectAndCompute(capture, None)
+    if des1 is None: return None
+    d1 = des1.get() if isinstance(des1, cv2.UMat) else des1
+    d2 = ctx['des'].get() if isinstance(ctx['des'], cv2.UMat) else ctx['des']
+    matches = ctx['flann'].knnMatch(d1, d2, k=2)
+    return do_homography(kp1, ctx['kp'], ratio_test(matches), capture.shape)
+
+run_match(setup_flann, match_flann, "2. SIFT + FLANN (trees=5)", "KD-tree")
+
+# ── 3. ORB ─────────────────────────────────────────────────────────────
+def setup_orb():
+    orb = cv2.ORB_create(nfeatures=3000)
+    bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=False)
+    kp, des = orb.detectAndCompute(img, None)
+    return {'orb': orb, 'bf': bf, 'kp': kp, 'des': des}
+
+def match_orb(capture, ctx):
+    kp1, des1 = ctx['orb'].detectAndCompute(capture, None)
+    if des1 is None: return None
+    matches = ctx['bf'].knnMatch(des1, ctx['des'], k=2)
+    return do_homography(kp1, ctx['kp'], ratio_test(matches), capture.shape)
+
+run_match(setup_orb, match_orb, "3. ORB (nfeat=3000)", "binary desc")
+
+# ── 4. AKAZE ───────────────────────────────────────────────────────────
+def setup_akaze():
+    akaze = cv2.AKAZE_create()
+    bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=False)
+    kp, des = akaze.detectAndCompute(img, None)
+    return {'det': akaze, 'bf': bf, 'kp': kp, 'des': des}
+
+def match_akaze(capture, ctx):
+    kp1, des1 = ctx['det'].detectAndCompute(capture, None)
+    if des1 is None: return None
+    matches = ctx['bf'].knnMatch(des1, ctx['des'], k=2)
+    return do_homography(kp1, ctx['kp'], ratio_test(matches), capture.shape)
+
+run_match(setup_akaze, match_akaze, "4. AKAZE", "binary desc")
+
+# ── 5. Template matching ──────────────────────────────────────────────
+def setup_template():
+    return {'map': img}
+
+def match_template(capture, ctx):
+    result = cv2.matchTemplate(ctx['map'], capture, cv2.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv2.minMaxLoc(result)
+    if max_val < 0.5: return None
+    return np.array([[[max_loc[0] + capture.shape[1]//2,
+                       max_loc[1] + capture.shape[0]//2]]], dtype=np.float32)
+
+run_match(setup_template, match_template, "5. Template matching", "no rotation")
+
+# ── 6. Downscale capture 2x ───────────────────────────────────────────
+def setup_ds_cap():
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(contrastThreshold=0.03)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift_map.detectAndCompute(img, None)
+    return {'sift': sift_cap, 'bf': bf, 'kp': kp, 'des': des}
+
+def match_ds_cap(capture, ctx):
+    small = cv2.resize(capture, (capture.shape[1]//2, capture.shape[0]//2))
+    kp1, des1 = ctx['sift'].detectAndCompute(small, None)
+    if des1 is None: return None
+    matches = ctx['bf'].knnMatch(des1, ctx['des'], k=2)
+    good = ratio_test(matches)
+    if len(good) <= 25: return None
+    src = np.float32([kp1[m.queryIdx].pt for m in good]).reshape(-1, 1, 2) * 2
+    dst = np.float32([ctx['kp'][m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    M, _ = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
+    if M is None or not np.all(np.isfinite(M)): return None
+    pts = np.float32([[0,0],[0,249],[249,249],[249,0]]).reshape(-1,1,2)
+    tp = cv2.perspectiveTransform(pts, M)
+    return tp if np.all(np.isfinite(tp)) else None
+
+run_match(setup_ds_cap, match_ds_cap, "6. Downscale capture 2x", "fewer cap kp")
+
+# ── 7. Downscale map+capture 2x ──────────────────────────────────────
+def setup_ds_both():
+    small_map = cv2.resize(img, (w//2, h//2))
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(contrastThreshold=0.03)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift_map.detectAndCompute(small_map, None)
+    return {'sift': sift_cap, 'bf': bf, 'kp': kp, 'des': des, 'scale': 2}
+
+def match_ds_both(capture, ctx):
+    small = cv2.resize(capture, (capture.shape[1]//2, capture.shape[0]//2))
+    kp1, des1 = ctx['sift'].detectAndCompute(small, None)
+    if des1 is None: return None
+    matches = ctx['bf'].knnMatch(des1, ctx['des'], k=2)
+    good = ratio_test(matches)
+    if len(good) <= 25: return None
+    src = np.float32([kp1[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+    dst = np.float32([ctx['kp'][m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    M, _ = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
+    if M is None or not np.all(np.isfinite(M)): return None
+    h2, w2 = capture.shape[0]//2, capture.shape[1]//2
+    pts = np.float32([[0,0],[0,h2-1],[w2-1,h2-1],[w2-1,0]]).reshape(-1,1,2)
+    tp = cv2.perspectiveTransform(pts, M)
+    return (tp * ctx['scale']) if np.all(np.isfinite(tp)) else None
+
+run_match(setup_ds_both, match_ds_both, "7. Downscale map+capture 2x", "half-res")
+
+# ── 8. Spatial restriction with known last pos ────────────────────────
+def setup_spatial():
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(contrastThreshold=0.03)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift_map.detectAndCompute(img, None)
+    # Build spatial grid
+    cell = 100
+    grid = {}
+    for i, k in enumerate(kp):
+        key = (int(k.pt[0] // cell), int(k.pt[1] // cell))
+        grid.setdefault(key, []).append(i)
+    des_np = des.get() if isinstance(des, cv2.UMat) else des
+    return {'sift': sift_cap, 'bf': bf, 'kp': kp, 'des_np': des_np,
+            'grid': grid, 'cell': cell}
+
+def match_spatial_warm(capture, ctx, last_pos=(425, 325)):
+    kp1, des1 = ctx['sift'].detectAndCompute(capture, None)
+    if des1 is None: return None
+    # Gather descriptors within radius
+    radius = 250
+    cs = ctx['cell']
+    cx_min = max(0, int((last_pos[0] - radius) // cs))
+    cx_max = int((last_pos[0] + radius) // cs) + 1
+    cy_min = max(0, int((last_pos[1] - radius) // cs))
+    cy_max = int((last_pos[1] + radius) // cs) + 1
+    indices = []
+    for cx in range(cx_min, cx_max + 1):
+        for cy in range(cy_min, cy_max + 1):
+            if (cx, cy) in ctx['grid']:
+                indices.extend(ctx['grid'][(cx, cy)])
+    if len(indices) < 100:
+        # Fallback to full
+        des_search = ctx['des_np']
+        kp_search = ctx['kp']
+    else:
+        indices = sorted(set(indices))
+        des_search = ctx['des_np'][indices]
+        kp_search = [ctx['kp'][i] for i in indices]
+    matches = ctx['bf'].knnMatch(des1, des_search, k=2)
+    good = ratio_test(matches)
+    if len(good) <= 25: return None
+    src = np.float32([kp1[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+    dst = np.float32([kp_search[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    M, _ = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
+    if M is None or not np.all(np.isfinite(M)): return None
+    pts = np.float32([[0,0],[0,249],[249,249],[249,0]]).reshape(-1,1,2)
+    tp = cv2.perspectiveTransform(pts, M)
+    return tp if np.all(np.isfinite(tp)) else None
+
+ctx8 = setup_spatial()
+# Warm
+match_spatial_warm(crop, ctx8)
+t0 = time.perf_counter()
+for _ in range(N):
+    match_spatial_warm(crop, ctx8, last_pos=(425, 325))
+t8 = (time.perf_counter() - t0) / N * 1000
+fn8 = "OK" if match_spatial_warm(crop, ctx8) is not None else "FAIL"
+# Snow test with appropriate last_pos
+fs8 = "OK" if match_spatial_warm(snow_crop, ctx8, last_pos=(w//2, h//5)) is not None else "FAIL"
+print(f"  {'8. Spatial (250px radius, warm)':<45} {t8:>6.1f}ms  {fn8:<6} {fs8:<6} needs last_pos")
+
+# ── 9. SIFT capped 500 + sensitive ───────────────────────────────────
+def setup_capped():
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(nfeatures=500, contrastThreshold=0.03)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift_map.detectAndCompute(img, None)
+    return {'sift': sift_cap, 'bf': bf, 'kp': kp, 'des': des}
+
+run_match(setup_capped, match_current, "9. SIFT nfeat=500, ct=0.03", "capped")
+
+# ── 10. SIFT capped 300 ──────────────────────────────────────────────
+def setup_cap300():
+    sift_map = cv2.SIFT_create()
+    sift_cap = cv2.SIFT_create(nfeatures=300, contrastThreshold=0.03)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift_map.detectAndCompute(img, None)
+    return {'sift': sift_cap, 'bf': bf, 'kp': kp, 'des': des}
+
+run_match(setup_cap300, match_current, "10. SIFT nfeat=300, ct=0.03", "aggressive cap")
+
+# ── 11. Spatial + FLANN combo ─────────────────────────────────────────
+# (Would combine approaches 2+8 but let's skip complex combos for now)
+
+# ── 12. SIFT + nfeat=500 cap + BF, original ct=0.04 (old baseline) ──
+def setup_old_baseline():
+    sift = cv2.SIFT_create(nfeatures=500)
+    bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+    kp, des = sift.detectAndCompute(img, None)
+    return {'sift': cv2.SIFT_create(nfeatures=500), 'bf': bf, 'kp': kp, 'des': des}
+
+run_match(setup_old_baseline, match_current, "12. OLD BASELINE (nf=500, ct=0.04)", "reference")
+
+print(f"\n{'='*90}")
+print("  NOTES:")
+print("  - 'Normal' = green/urban crop, 'Snow' = snow area crop from map")
+print("  - Template matching has no rotation invariance (bad for real minimap)")
+print("  - Spatial restriction needs a last known position (first frame = full search)")
+print(f"{'='*90}")

--- a/tests/test_ppi_benchmark.py
+++ b/tests/test_ppi_benchmark.py
@@ -1,0 +1,407 @@
+"""PPI performance benchmark tests.
+
+Compares old (brute-force, raw mss, deep-copy config) vs new (FLANN, screenshot manager,
+cached config) implementations for speed and accuracy.
+"""
+import os
+import sys
+import time
+import configparser
+import threading
+import numpy as np
+import cv2
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def synthetic_map():
+    """Generate a synthetic grayscale 'map' image with SIFT-friendly features."""
+    rng = np.random.RandomState(42)
+    img = rng.randint(30, 220, (1024, 1024), dtype=np.uint8)
+    # Add blobs / circles so SIFT has keypoints to find
+    for _ in range(80):
+        cx, cy = rng.randint(50, 974, size=2)
+        r = rng.randint(10, 40)
+        cv2.circle(img, (int(cx), int(cy)), int(r), int(rng.randint(0, 255)), -1)
+    # Gaussian blur so features have scale-space structure
+    img = cv2.GaussianBlur(img, (5, 5), 1.5)
+    return img
+
+
+@pytest.fixture
+def synthetic_capture(synthetic_map):
+    """Extract a 250x250 crop from the map (simulating a minimap capture)."""
+    return synthetic_map[200:450, 300:550].copy()
+
+
+# ---------------------------------------------------------------------------
+# Old (baseline) implementations — inlined here for comparison
+# ---------------------------------------------------------------------------
+
+class OldMapManager:
+    """Baseline MapManager using BFMatcher and unconstrained SIFT."""
+
+    def __init__(self):
+        self.sift = cv2.SIFT_create()  # no nfeatures limit
+        self.bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+        self.keypoints = None
+        self.descriptors = None
+
+    def load_map(self, img):
+        self.keypoints, self.descriptors = self.sift.detectAndCompute(img, None)
+
+    def find_best_match(self, captured_area):
+        kp1, des1 = self.sift.detectAndCompute(captured_area, None)
+        if des1 is None or self.descriptors is None:
+            return None
+        matches = self.bf.knnMatch(des1, self.descriptors, k=2)
+        good = []
+        for pair in matches:
+            if len(pair) == 2:
+                m, n = pair
+                if m.distance < 0.75 * n.distance:
+                    good.append(m)
+        if len(good) <= 25:
+            return None
+        src = np.float32([kp1[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+        dst = np.float32([self.keypoints[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+        M, _ = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
+        if M is None or not np.all(np.isfinite(M)):
+            return None
+        h, w = captured_area.shape[:2]
+        pts = np.float32([[0, 0], [0, h-1], [w-1, h-1], [w-1, 0]]).reshape(-1, 1, 2)
+        transformed = cv2.perspectiveTransform(pts, M)
+        return transformed if np.all(np.isfinite(transformed)) else None
+
+
+class NewMapManager:
+    """Optimized MapManager using limited SIFT for captures, BFMatcher kept."""
+
+    def __init__(self):
+        self.sift_capture = cv2.SIFT_create(nfeatures=500)
+        self.sift_map = cv2.SIFT_create()
+        self.bf = cv2.BFMatcher(cv2.NORM_L2, crossCheck=False)
+        self.keypoints = None
+        self.descriptors = None
+
+    def load_map(self, img):
+        self.keypoints, self.descriptors = self.sift_map.detectAndCompute(img, None)
+
+    def find_best_match(self, captured_area):
+        kp1, des1 = self.sift_capture.detectAndCompute(captured_area, None)
+        if des1 is None or self.descriptors is None:
+            return None
+        matches = self.bf.knnMatch(des1, self.descriptors, k=2)
+        good = []
+        for pair in matches:
+            if len(pair) == 2:
+                m, n = pair
+                if m.distance < 0.75 * n.distance:
+                    good.append(m)
+        if len(good) <= 25:
+            return None
+        src = np.float32([kp1[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+        dst = np.float32([self.keypoints[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+        M, _ = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
+        if M is None or not np.all(np.isfinite(M)):
+            return None
+        h, w = captured_area.shape[:2]
+        pts = np.float32([[0, 0], [0, h-1], [w-1, h-1], [w-1, 0]]).reshape(-1, 1, 2)
+        transformed = cv2.perspectiveTransform(pts, M)
+        return transformed if np.all(np.isfinite(transformed)) else None
+
+
+def _old_read_config_copy(config_cache):
+    """Simulate old read_config that deep-copies via iteration."""
+    new_config = configparser.ConfigParser()
+    new_config.optionxform = str
+    for section in config_cache.sections():
+        new_config.add_section(section)
+        for key, value in config_cache.items(section):
+            new_config.set(section, key, value)
+    return new_config
+
+
+def _new_read_config_copy(config_cache):
+    """Simulate new read_config that returns cache directly."""
+    return config_cache
+
+
+# ---------------------------------------------------------------------------
+# Benchmark helpers
+# ---------------------------------------------------------------------------
+
+def _build_sample_config():
+    """Build a realistic ConfigParser with many sections/keys."""
+    config = configparser.ConfigParser()
+    config.optionxform = str
+    for section_name in ['General', 'POI', 'GameObjects', 'GameObjects_Main',
+                         'Audio', 'Display', 'Keybinds', 'Advanced']:
+        config.add_section(section_name)
+        for i in range(20):
+            config.set(section_name, f'Key{i}', f'value_{i}')
+    config.set('POI', 'current_map', 'main')
+    return config
+
+
+def _center_from_match(match_result):
+    """Extract center point from a match result (same as PPI does)."""
+    if match_result is None:
+        return None
+    return tuple(np.mean(match_result, axis=0).reshape(-1).astype(int))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestMatcherBenchmark:
+    """Compare unlimited SIFT + BFMatcher (old) vs limited SIFT + BFMatcher (new)."""
+
+    def test_limited_sift_matching_speed(self, synthetic_map, synthetic_capture):
+        """Limited SIFT should produce fewer descriptors, making matching faster."""
+        old = OldMapManager()
+        old.load_map(synthetic_map)
+
+        new = NewMapManager()
+        new.load_map(synthetic_map)
+
+        iterations = 20
+
+        # Warm up
+        old.find_best_match(synthetic_capture)
+        new.find_best_match(synthetic_capture)
+
+        # Benchmark old (unlimited SIFT)
+        start = time.perf_counter()
+        for _ in range(iterations):
+            old.find_best_match(synthetic_capture)
+        old_elapsed = time.perf_counter() - start
+
+        # Benchmark new (limited SIFT nfeatures=500)
+        start = time.perf_counter()
+        for _ in range(iterations):
+            new.find_best_match(synthetic_capture)
+        new_elapsed = time.perf_counter() - start
+
+        speedup = old_elapsed / new_elapsed if new_elapsed > 0 else float('inf')
+
+        print(f"\n--- Matcher Benchmark ({iterations} iterations) ---")
+        print(f"  Old (unlimited SIFT): {old_elapsed:.3f}s  ({old_elapsed/iterations*1000:.1f}ms/iter)")
+        print(f"  New (limited SIFT):   {new_elapsed:.3f}s  ({new_elapsed/iterations*1000:.1f}ms/iter)")
+        print(f"  Speedup:              {speedup:.2f}x")
+
+        # New should not be significantly slower (limited SIFT reduces work)
+        assert new_elapsed <= old_elapsed * 1.3, (
+            f"Limited SIFT ({new_elapsed:.3f}s) should not be much slower than unlimited ({old_elapsed:.3f}s)"
+        )
+
+    def test_accuracy_parity(self, synthetic_map, synthetic_capture):
+        """Both matchers should find the same region (or both fail)."""
+        old = OldMapManager()
+        old.load_map(synthetic_map)
+        old_result = old.find_best_match(synthetic_capture)
+
+        new = NewMapManager()
+        new.load_map(synthetic_map)
+        new_result = new.find_best_match(synthetic_capture)
+
+        old_center = _center_from_match(old_result)
+        new_center = _center_from_match(new_result)
+
+        print(f"\n--- Accuracy Comparison ---")
+        print(f"  Old center: {old_center}")
+        print(f"  New center: {new_center}")
+
+        if old_center is None and new_center is None:
+            pytest.skip("Both matchers failed to find matches (synthetic data too random)")
+
+        if old_center is not None and new_center is not None:
+            distance = np.sqrt((old_center[0] - new_center[0])**2 +
+                               (old_center[1] - new_center[1])**2)
+            print(f"  Pixel distance: {distance:.1f}")
+            # Allow up to 30px divergence since FLANN is approximate
+            assert distance < 30, (
+                f"Matcher results diverge by {distance:.1f}px (limit: 30px)"
+            )
+
+
+class TestConfigReadBenchmark:
+    """Compare old deep-copy read_config vs new direct-return."""
+
+    def test_config_read_speed(self):
+        """Direct cache return should be much faster than deep-copy iteration."""
+        config = _build_sample_config()
+        iterations = 5000
+
+        # Warm up
+        _old_read_config_copy(config)
+        _new_read_config_copy(config)
+
+        # Benchmark old (deep copy via iteration)
+        start = time.perf_counter()
+        for _ in range(iterations):
+            _old_read_config_copy(config)
+        old_elapsed = time.perf_counter() - start
+
+        # Benchmark new (direct return)
+        start = time.perf_counter()
+        for _ in range(iterations):
+            _new_read_config_copy(config)
+        new_elapsed = time.perf_counter() - start
+
+        speedup = old_elapsed / new_elapsed if new_elapsed > 0 else float('inf')
+
+        print(f"\n--- Config Read Benchmark ({iterations} iterations) ---")
+        print(f"  Old (deep copy):    {old_elapsed:.3f}s  ({old_elapsed/iterations*1000:.3f}ms/iter)")
+        print(f"  New (direct return): {new_elapsed:.3f}s  ({new_elapsed/iterations*1000:.3f}ms/iter)")
+        print(f"  Speedup:            {speedup:.0f}x")
+
+        assert new_elapsed < old_elapsed, (
+            f"Direct return ({new_elapsed:.3f}s) should be faster than deep copy ({old_elapsed:.3f}s)"
+        )
+
+    def test_config_event_vs_polling(self):
+        """Simulated config event cache vs repeated read_config polling."""
+        config = _build_sample_config()
+        iterations = 5000
+
+        # Simulate polling: read config + extract value each time
+        start = time.perf_counter()
+        for _ in range(iterations):
+            cfg = _old_read_config_copy(config)
+            _ = cfg.get('POI', 'current_map', fallback='main')
+        polling_elapsed = time.perf_counter() - start
+
+        # Simulate event-driven: cached value, just read the variable
+        cached_map = 'main'
+        start = time.perf_counter()
+        for _ in range(iterations):
+            _ = cached_map
+        event_elapsed = time.perf_counter() - start
+
+        speedup = polling_elapsed / event_elapsed if event_elapsed > 0 else float('inf')
+
+        print(f"\n--- Config Polling vs Event Benchmark ({iterations} iterations) ---")
+        print(f"  Polling (read_config + get): {polling_elapsed:.3f}s")
+        print(f"  Event-driven (cached var):   {event_elapsed:.6f}s")
+        print(f"  Speedup:                     {speedup:.0f}x")
+
+        assert event_elapsed < polling_elapsed
+
+
+class TestSIFTFeatureLimitBenchmark:
+    """Compare unconstrained vs limited SIFT on capture-sized images."""
+
+    def test_sift_speed(self, synthetic_capture):
+        """Limited SIFT (nfeatures=500) should be faster on capture images."""
+        sift_unlimited = cv2.SIFT_create()
+        sift_limited = cv2.SIFT_create(nfeatures=500)
+        iterations = 30
+
+        # Warm up
+        sift_unlimited.detectAndCompute(synthetic_capture, None)
+        sift_limited.detectAndCompute(synthetic_capture, None)
+
+        # Benchmark unlimited
+        start = time.perf_counter()
+        for _ in range(iterations):
+            kp_u, des_u = sift_unlimited.detectAndCompute(synthetic_capture, None)
+        unlimited_elapsed = time.perf_counter() - start
+
+        # Benchmark limited
+        start = time.perf_counter()
+        for _ in range(iterations):
+            kp_l, des_l = sift_limited.detectAndCompute(synthetic_capture, None)
+        limited_elapsed = time.perf_counter() - start
+
+        kp_unlimited = len(kp_u) if kp_u else 0
+        kp_limited = len(kp_l) if kp_l else 0
+
+        print(f"\n--- SIFT Feature Limit Benchmark ({iterations} iterations) ---")
+        print(f"  Unlimited:  {unlimited_elapsed:.3f}s  ({kp_unlimited} keypoints)")
+        print(f"  Limited:    {limited_elapsed:.3f}s  ({kp_limited} keypoints)")
+        print(f"  Speedup:    {unlimited_elapsed/limited_elapsed:.2f}x")
+
+        # Limited should produce fewer or equal keypoints
+        assert kp_limited <= kp_unlimited or kp_unlimited <= 500
+
+
+class TestScreenCaptureMethod:
+    """Compare raw mss() creation vs reusing ScreenshotManager."""
+
+    def test_mss_creation_overhead(self):
+        """Reusing an MSS instance should be faster than recreating each time."""
+        from mss import mss
+        iterations = 50
+
+        # Benchmark: create new mss() each time (old approach)
+        start = time.perf_counter()
+        for _ in range(iterations):
+            with mss() as sct:
+                pass  # Just measure init/teardown overhead
+        old_elapsed = time.perf_counter() - start
+
+        # Benchmark: reuse single instance (new approach via ScreenshotManager)
+        sct = mss()
+        start = time.perf_counter()
+        for _ in range(iterations):
+            _ = sct  # Just accessing the existing instance
+        new_elapsed = time.perf_counter() - start
+        sct.close()
+
+        print(f"\n--- MSS Instance Benchmark ({iterations} iterations) ---")
+        print(f"  New each time: {old_elapsed:.3f}s  ({old_elapsed/iterations*1000:.1f}ms/iter)")
+        print(f"  Reuse:         {new_elapsed:.6f}s")
+        print(f"  Overhead saved: {old_elapsed - new_elapsed:.3f}s")
+
+        assert new_elapsed < old_elapsed
+
+
+class TestEndToEndPPI:
+    """End-to-end PPI pipeline comparison using synthetic data."""
+
+    def test_full_pipeline_speed(self, synthetic_map, synthetic_capture):
+        """Full old pipeline vs new pipeline timing — config overhead dominates."""
+        iterations = 50
+
+        # Old pipeline: deep-copy config each iteration + unlimited SIFT matching
+        old = OldMapManager()
+        old.load_map(synthetic_map)
+        config = _build_sample_config()
+
+        start = time.perf_counter()
+        for _ in range(iterations):
+            cfg = _old_read_config_copy(config)
+            _ = cfg.get('POI', 'current_map', fallback='main')
+            old.find_best_match(synthetic_capture)
+        old_elapsed = time.perf_counter() - start
+
+        # New pipeline: cached config + limited SIFT matching
+        new = NewMapManager()
+        new.load_map(synthetic_map)
+        cached_map = 'main'
+
+        start = time.perf_counter()
+        for _ in range(iterations):
+            _ = cached_map  # event-driven cached value
+            new.find_best_match(synthetic_capture)
+        new_elapsed = time.perf_counter() - start
+
+        speedup = old_elapsed / new_elapsed if new_elapsed > 0 else float('inf')
+
+        print(f"\n--- End-to-End PPI Benchmark ({iterations} iterations) ---")
+        print(f"  Old pipeline: {old_elapsed:.3f}s  ({old_elapsed/iterations*1000:.1f}ms/iter)")
+        print(f"  New pipeline: {new_elapsed:.3f}s  ({new_elapsed/iterations*1000:.1f}ms/iter)")
+        print(f"  Speedup:      {speedup:.2f}x")
+
+        # New pipeline should be at least slightly faster (config overhead removed)
+        assert new_elapsed <= old_elapsed * 1.05, (
+            f"New pipeline ({new_elapsed:.3f}s) should not be slower than old ({old_elapsed:.3f}s)"
+        )


### PR DESCRIPTION
## Summary
- `--benchmark`: single-shot navigation pipeline benchmark with step-by-step timing breakdown, saved to benchmark_results.txt
- `--profile`: real-time per-function profiling across all FA11y modules with live periodic summaries and session report on exit
- 116 function hooks covering: PPI, player_position, screenshot_manager, match_tracker, spatial_audio, audio_engine, config, hotbar, OCR, game objects, POI data, lobby reader, exit match, HSR, mouse, input, all monitors, epic auth, social
- Zero overhead when neither flag is passed (no-op early returns)
- Results saved periodically and on Ctrl+C via signal handler + fsync
- Usage: `python FA11y.py --profile`, `python FA11y.py --benchmark --runs 5`