### PR TITLE
Consolidate screen capture and fix inventory responsiveness

### DIFF
--- a/lib/managers/inventory_manager.py
+++ b/lib/managers/inventory_manager.py
@@ -5,7 +5,6 @@ from lib.utilities.mouse import (
     get_mouse_position, move_to, left_mouse_up, left_mouse_down,
     pixel as read_pixel
 )
-from mss import mss
 import numpy as np
 import os
 import pickle
@@ -164,34 +163,32 @@ class InventoryManager:
         self.last_inventory_check = current_time
         
         try:
-            # Use MSS for efficient screenshot of small region
-            with mss() as sct:
-                screenshot = np.array(sct.grab(self.inventory_region))
-                
-                # Convert to RGB for easier pixel checking
-                if screenshot.shape[2] == 4:
-                    screenshot = cv2.cvtColor(screenshot, cv2.COLOR_BGRA2RGB)
-                
-                # Check all key pixels in the screenshot
-                all_coords = []
-                # Add vertical line pixels
-                all_coords.extend(self.key_pixels[0])
-                # Add individual pixels  
-                for i in range(1, len(self.key_pixels)):
-                    all_coords.append(self.key_pixels[i])
-                
-                # Check if all pixels are white
-                for x, y in all_coords:
-                    if y >= screenshot.shape[0] or x >= screenshot.shape[1]:
-                        continue
-                    pixel = screenshot[y, x]
-                    if not (pixel[0] == 255 and pixel[1] == 255 and pixel[2] == 255):
-                        self._last_inventory_state = False
-                        return False
-                
-                self._last_inventory_state = True
-                return True
-                
+            from lib.managers.screenshot_manager import screenshot_manager
+            screenshot = screenshot_manager.capture_region(self.inventory_region, convert_format='rgb')
+            if screenshot is None:
+                self._last_inventory_state = False
+                return False
+
+            # Check all key pixels in the screenshot
+            all_coords = []
+            # Add vertical line pixels
+            all_coords.extend(self.key_pixels[0])
+            # Add individual pixels
+            for i in range(1, len(self.key_pixels)):
+                all_coords.append(self.key_pixels[i])
+
+            # Check if all pixels are white
+            for x, y in all_coords:
+                if y >= screenshot.shape[0] or x >= screenshot.shape[1]:
+                    continue
+                pixel = screenshot[y, x]
+                if not (pixel[0] == 255 and pixel[1] == 255 and pixel[2] == 255):
+                    self._last_inventory_state = False
+                    return False
+
+            self._last_inventory_state = True
+            return True
+
         except Exception:
             self._last_inventory_state = False
             return False
@@ -266,42 +263,19 @@ class InventoryManager:
                 pass
 
     def _execute_movement(self, target_x, target_y):
-        """Execute a smooth mouse movement to the target coordinates"""
-        start_x, start_y = get_mouse_position()
-        
-        # Optimize if already close to target
-        if abs(start_x - target_x) < 5 and abs(start_y - target_y) < 5:
-            move_to(target_x, target_y)
-            return
-
-        def ease_out_cubic(t):
-            """Cubic easing function for smooth movement"""
-            return 1 - pow(1 - t, 3)
-
-        for step in range(self.MOVEMENT_STEPS + 1):
-            if self.stop_monitoring.is_set():
-                break
-                
-            t = step / self.MOVEMENT_STEPS
-            eased_t = ease_out_cubic(t)
-            
-            current_x = int(start_x + (target_x - start_x) * eased_t)
-            current_y = int(start_y + (target_y - start_y) * eased_t)
-            
-            move_to(current_x, current_y)
-            time.sleep(self.MOVEMENT_DURATION / self.MOVEMENT_STEPS)
+        """Move cursor to target coordinates instantly via FakerInput."""
+        move_to(target_x, target_y)
 
     def smooth_move_to(self, x, y):
-        """Queue a smooth movement request"""
-        # Don't queue if already processing similar coordinates
+        """Queue a movement request, clearing any pending moves so rapid
+        key presses jump straight to the latest target."""
+        # Drain any pending moves — we only care about the newest destination
         try:
-            if not self.movement_queue.empty():
-                last_x, last_y = self.movement_queue.queue[-1]
-                if abs(last_x - x) < 10 and abs(last_y - y) < 10:
-                    return
-        except:
+            while not self.movement_queue.empty():
+                self.movement_queue.get_nowait()
+                self.movement_queue.task_done()
+        except Exception:
             pass
-        
         self.movement_queue.put((x, y))
 
     def check_pixel_color(self, x, y, target_color, tolerance=2):

--- a/lib/monitors/background_monitor.py
+++ b/lib/monitors/background_monitor.py
@@ -2,10 +2,10 @@ import threading
 import time
 import cv2
 import numpy as np
-from mss import mss
 from pathlib import Path
 from accessible_output2.outputs.auto import Auto
 from lib.utilities.utilities import read_config, get_config_boolean, on_config_change
+from lib.managers.screenshot_manager import screenshot_manager as _ss_mgr
 
 class BackgroundMonitor:
     def __init__(self):
@@ -75,25 +75,12 @@ class BackgroundMonitor:
             self._inventory_open = value
 
     def get_mss(self):
-        """Get thread-local MSS instance with proper error handling."""
-        with self.mss_lock:
-            if not hasattr(self.thread_local, 'mss'):
-                try:
-                    self.thread_local.mss = mss()
-                except Exception:
-                    return None
-            return self.thread_local.mss
+        """Get MSS instance via shared ScreenshotManager."""
+        return _ss_mgr.get_mss_instance()
 
     def cleanup_mss(self):
-        """Clean up MSS instance for current thread."""
-        with self.mss_lock:
-            if hasattr(self.thread_local, 'mss'):
-                try:
-                    self.thread_local.mss.close()
-                except Exception:
-                    pass
-                finally:
-                    delattr(self.thread_local, 'mss')
+        """Clean up MSS instance for current thread via ScreenshotManager."""
+        _ss_mgr.cleanup_thread_resources()
 
     def reload_config(self):
         """Reload configuration values."""
@@ -137,16 +124,8 @@ class BackgroundMonitor:
             return False
 
     def _get_pixel(self, x, y):
-        """Read a single pixel using thread-local mss. Returns (R, G, B) or None."""
-        try:
-            mss_instance = self.get_mss()
-            if mss_instance is None:
-                return None
-            img = mss_instance.grab({'left': x, 'top': y, 'width': 1, 'height': 1})
-            b, g, r = img.pixel(0, 0)[:3]
-            return (r, g, b)
-        except Exception:
-            return None
+        """Read a single pixel using shared ScreenshotManager. Returns (R, G, B) or None."""
+        return _ss_mgr.get_pixel(x, y)
 
     def check_map_status(self):
         """Check if the map is open/closed with throttling."""
@@ -180,11 +159,9 @@ class BackgroundMonitor:
             return
             
         try:
-            mss_instance = self.get_mss()
-            if mss_instance is None:
+            screenshot = _ss_mgr.capture_region(self.inventory_region, convert_format='raw')
+            if screenshot is None:
                 return
-                
-            screenshot = np.array(mss_instance.grab(self.inventory_region))
             is_escape_visible = self.detect_escape_key(screenshot)
             
             if is_escape_visible != self.inventory_open:

--- a/lib/monitors/bloom_monitor.py
+++ b/lib/monitors/bloom_monitor.py
@@ -11,10 +11,10 @@ Runs at 24 FPS, scanning a 150x150 region around screen center (960, 540).
 import threading
 import time
 import numpy as np
-from mss import mss
 from accessible_output2.outputs.auto import Auto
 from lib.utilities.utilities import read_config, get_config_boolean, on_config_change
 from lib.monitors.background_monitor import monitor
+from lib.managers.screenshot_manager import screenshot_manager
 
 # Screen center
 CX, CY = 960, 540
@@ -163,47 +163,47 @@ class BloomMonitor:
 
     def _monitor_loop(self):
         """Main monitor loop at 24 FPS."""
-        with mss() as sct:
-            while not self.stop_event.is_set():
-                loop_start = time.perf_counter()
+        while not self.stop_event.is_set():
+            loop_start = time.perf_counter()
 
-                try:
-                    # Skip if map is open or disabled in config
-                    if monitor.map_open or not self.is_enabled():
-                        self._last_bloom_dist = None
-                        time.sleep(0.25)
-                        continue
+            try:
+                # Skip if map is open or disabled in config
+                if monitor.map_open or not self.is_enabled():
+                    self._last_bloom_dist = None
+                    time.sleep(0.25)
+                    continue
 
-                    # Capture region
-                    raw = np.array(sct.grab(REGION))
-                    # Convert BGRA to RGB
-                    img = raw[:, :, :3][:, :, ::-1]
+                # Capture region via shared ScreenshotManager (thread-local mss reuse)
+                img = screenshot_manager.capture_region(REGION, convert_format='rgb')
+                if img is None:
+                    time.sleep(FRAME_INTERVAL)
+                    continue
 
-                    # Check if crosshair is visible
-                    if not self._is_center_crosshair(img):
-                        self._last_bloom_dist = None
-                        elapsed = time.perf_counter() - loop_start
-                        remaining = FRAME_INTERVAL - elapsed
-                        if remaining > 0:
-                            time.sleep(remaining)
-                        continue
+                # Check if crosshair is visible
+                if not self._is_center_crosshair(img):
+                    self._last_bloom_dist = None
+                    elapsed = time.perf_counter() - loop_start
+                    remaining = FRAME_INTERVAL - elapsed
+                    if remaining > 0:
+                        time.sleep(remaining)
+                    continue
 
-                    # Detect bloom - only play when distance changes
-                    bloom_dist = self._detect_bloom(img)
-                    if bloom_dist is not None:
-                        if bloom_dist != self._last_bloom_dist:
-                            self._play_bloom_tone(bloom_dist)
-                            self._last_bloom_dist = bloom_dist
-                    else:
-                        self._last_bloom_dist = None
+                # Detect bloom - only play when distance changes
+                bloom_dist = self._detect_bloom(img)
+                if bloom_dist is not None:
+                    if bloom_dist != self._last_bloom_dist:
+                        self._play_bloom_tone(bloom_dist)
+                        self._last_bloom_dist = bloom_dist
+                else:
+                    self._last_bloom_dist = None
 
-                except Exception:
-                    pass
+            except Exception:
+                pass
 
-                elapsed = time.perf_counter() - loop_start
-                remaining = FRAME_INTERVAL - elapsed
-                if remaining > 0:
-                    time.sleep(remaining)
+            elapsed = time.perf_counter() - loop_start
+            remaining = FRAME_INTERVAL - elapsed
+            if remaining > 0:
+                time.sleep(remaining)
 
     def start_monitoring(self):
         """Start the bloom monitor."""

--- a/lib/monitors/material_monitor.py
+++ b/lib/monitors/material_monitor.py
@@ -1,12 +1,12 @@
 import cv2
 import numpy as np
-from mss import mss
 import os
 from threading import Thread, Event, Lock
 from accessible_output2.outputs.auto import Auto
 import time
 from pathlib import Path
 from lib.managers.ocr_manager import get_ocr_manager
+from lib.managers.screenshot_manager import screenshot_manager
 
 # Screen coordinates
 MATERIAL_ICON_AREA = {
@@ -136,22 +136,22 @@ class MaterialMonitor:
             print(f"Error in count detection: {e}")
         return None
 
-    def _get_mss(self):
-        """Get persistent mss instance (avoids recreation every loop)."""
-        if self._mss_instance is None:
-            self._mss_instance = mss()
-        return self._mss_instance
+    def _capture(self, region):
+        """Capture a screen region via shared ScreenshotManager."""
+        return screenshot_manager.capture_region(region, convert_format='raw')
 
     def monitor_loop(self):
         """Main monitoring loop."""
-        sct = self._get_mss()
         try:
             last_material_time = 0
-            
+
             while not self.stop_event.is_set():
                 try:
-                    # Capture material icon area
-                    icon_screenshot = np.array(sct.grab(MATERIAL_ICON_AREA))
+                    # Capture material icon area via shared ScreenshotManager
+                    icon_screenshot = self._capture(MATERIAL_ICON_AREA)
+                    if icon_screenshot is None:
+                        time.sleep(0.3)
+                        continue
                     
                     # Detect material
                     detected_material = self.detect_material(icon_screenshot)
@@ -166,7 +166,7 @@ class MaterialMonitor:
                             self.last_count = None
                             
                             # Get initial count when new material detected
-                            count_screenshot = np.array(sct.grab(MATERIAL_COUNT_AREA))
+                            count_screenshot = self._capture(MATERIAL_COUNT_AREA)
                             current_count = self.detect_count(count_screenshot)
                             if current_count is not None:
                                 # Announce initial detection
@@ -174,7 +174,7 @@ class MaterialMonitor:
                                 self.last_count = current_count
                         else:
                             # Continue monitoring count for same material
-                            count_screenshot = np.array(sct.grab(MATERIAL_COUNT_AREA))
+                            count_screenshot = self._capture(MATERIAL_COUNT_AREA)
                             current_count = self.detect_count(count_screenshot)
                             
                             if current_count is not None and current_count != self.last_count:
@@ -194,12 +194,7 @@ class MaterialMonitor:
                     print(f"Error in material monitor loop: {e}")
                     time.sleep(0.5)
         finally:
-            if self._mss_instance:
-                try:
-                    self._mss_instance.close()
-                except Exception:
-                    pass
-                self._mss_instance = None
+            pass  # ScreenshotManager handles mss lifecycle
 
     def start_monitoring(self):
         """Start the material monitoring."""

--- a/lib/monitors/resource_monitor.py
+++ b/lib/monitors/resource_monitor.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy as np
-from mss import mss
 import os
 from threading import Thread, Event, Lock
 from accessible_output2.outputs.auto import Auto
@@ -8,6 +7,7 @@ import time
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, List
+from lib.managers.screenshot_manager import screenshot_manager
 from lib.managers.ocr_manager import get_ocr_manager
 
 # Screen monitoring configuration
@@ -216,18 +216,18 @@ class ResourceMonitor:
             print(f"Error in count detection: {e}")
         return None
 
-    def _get_mss(self):
-        """Get persistent mss instance."""
-        if self._mss_instance is None:
-            self._mss_instance = mss()
-        return self._mss_instance
+    def _capture(self, region):
+        """Capture a screen region via shared ScreenshotManager."""
+        return screenshot_manager.capture_region(region, convert_format='raw')
 
     def monitor_loop(self):
-        sct = self._get_mss()
         try:
             while not self.stop_event.is_set():
                 try:
-                    screenshot = np.array(sct.grab(SCAN_REGION))
+                    screenshot = self._capture(SCAN_REGION)
+                    if screenshot is None:
+                        time.sleep(0.3)
+                        continue
                     current_time = time.time()
                     
                     # Only process if the list is stable
@@ -253,7 +253,7 @@ class ResourceMonitor:
                                     'height': OCR_OFFSET['height']
                                 }
                                 
-                                count_screenshot = np.array(sct.grab(ocr_area))
+                                count_screenshot = self._capture(ocr_area)
                                 count = self.detect_count(count_screenshot, position, name, current_time)
                                 
                                 if count is not None:
@@ -293,7 +293,7 @@ class ResourceMonitor:
                                 'height': OCR_OFFSET['height']
                             }
                             
-                            count_screenshot = np.array(sct.grab(ocr_area))
+                            count_screenshot = self._capture(ocr_area)
                             current_count = self.detect_count(count_screenshot, state.position, name, current_time)
                             
                             if current_count is not None:
@@ -316,12 +316,7 @@ class ResourceMonitor:
                     print(f"Error in monitor loop: {str(e)}")
                     time.sleep(1.0)
         finally:
-            if self._mss_instance:
-                try:
-                    self._mss_instance.close()
-                except Exception:
-                    pass
-                self._mss_instance = None
+            pass  # ScreenshotManager handles mss lifecycle
 
     def start_monitoring(self):
         if not self.running:


### PR DESCRIPTION
## Summary
- Replace 5 separate mss() GDI handles (bloom, material, resource, background monitors + inventory_manager) with shared ScreenshotManager singleton
- Eliminates GDI contention that caused Fortnite rendering hitches when FA11y was running
- Inventory: drain movement queue on new input so rapid key presses skip to the latest target instead of queuing stale intermediate moves
- Inventory: use ScreenshotManager for inventory detection instead of creating mss() per call