### PR TITLE
Speed up FakerInput mouse operations and fix recapture freeze

### DIFF
--- a/lib/guis/discovery_gui.py
+++ b/lib/guis/discovery_gui.py
@@ -1120,11 +1120,11 @@ class DiscoveryDialog(AccessibleDialog):
                 time.sleep(0.3)
 
                 # Click initial position to open discovery
-                move_to_and_click(69, 69, duration=0.04)
+                move_to_and_click(69, 69)
                 time.sleep(0.5)
 
                 # Move mouse to scroll position
-                move_to(950, 470, duration=0.04)
+                move_to(950, 470)
                 time.sleep(0.1)
 
                 # Scroll down once
@@ -1136,7 +1136,7 @@ class DiscoveryDialog(AccessibleDialog):
                 time.sleep(1.1)  # Wait extra second for UI to settle
 
                 # Click to open search
-                move_to_and_click(160, 170, duration=0.04)
+                move_to_and_click(160, 170)
                 time.sleep(0.1)
 
                 # Type the gamemode code or title (use title for non-standard codes)
@@ -1176,13 +1176,13 @@ class DiscoveryDialog(AccessibleDialog):
                 time.sleep(0.1)
 
                 # Click the gamemode result
-                move_to_and_click(192, 493, duration=0.04)
+                move_to_and_click(192, 493)
                 time.sleep(0.15)
-                move_to_and_click(192, 493, duration=0.04)
+                move_to_and_click(192, 493)
                 time.sleep(0.7)
 
                 # Click to confirm/select
-                move_to_and_click(235, 923, duration=0.04)
+                move_to_and_click(235, 923)
                 time.sleep(0.5)
 
                 speaker.speak(f"{title} selected!")

--- a/lib/guis/gamemode_gui.py
+++ b/lib/guis/gamemode_gui.py
@@ -185,11 +185,11 @@ class GamemodeGUI(AccessibleDialog):
             time.sleep(0.3)
 
             # Click initial position to open discovery
-            move_to_and_click(69, 69, duration=0.04)
+            move_to_and_click(69, 69)
             time.sleep(0.5)
 
             # Move mouse to scroll position
-            move_to(950, 470, duration=0.04)
+            move_to(950, 470)
             time.sleep(0.1)
 
             # Scroll down once
@@ -201,7 +201,7 @@ class GamemodeGUI(AccessibleDialog):
             time.sleep(1.1)  # Wait extra second for UI to settle
 
             # Click to open search
-            move_to_and_click(160, 170, duration=0.04)
+            move_to_and_click(160, 170)
             time.sleep(0.1)
 
             # Type the gamemode code
@@ -239,13 +239,13 @@ class GamemodeGUI(AccessibleDialog):
             time.sleep(0.1)
 
             # Click the gamemode result
-            move_to_and_click(192, 493, duration=0.04)
+            move_to_and_click(192, 493)
             time.sleep(0.15)
-            move_to_and_click(192, 493, duration=0.04)
+            move_to_and_click(192, 493)
             time.sleep(0.7)
 
             # Click to confirm/select
-            move_to_and_click(235, 923, duration=0.04)
+            move_to_and_click(235, 923)
             time.sleep(0.5)
 
             return (True, None)

--- a/lib/mouse_passthrough/service.py
+++ b/lib/mouse_passthrough/service.py
@@ -115,12 +115,21 @@ class MousePassthroughService:
                 self._first_time_setup()
 
     def _first_time_setup(self):
-        """Guide the user through first-time mouse setup. Skippable."""
+        """Guide the user through first-time mouse setup. Skippable.
+
+        Runs detection on a background thread to avoid blocking the main thread
+        or key listener during the Win32 message pump.
+        """
         if self.speaker:
             self.speaker.speak("No mouse configured for passthrough. Move your mouse to detect it, or press Enter to skip.")
 
         print("[INFO] No mouse configured. Move your mouse to detect it (or wait to skip)...")
 
+        thread = threading.Thread(target=self._first_time_setup_blocking, daemon=True)
+        thread.start()
+
+    def _first_time_setup_blocking(self):
+        """Blocking first-time setup logic — runs on a background thread."""
         device = detect_mouse_device(
             dpi=self.config["DPI"],
             timeout=self.config["DETECTION_TIMEOUT"]
@@ -141,10 +150,20 @@ class MousePassthroughService:
             self.speaker.speak(f"Mouse passthrough started with {device.friendly_name} at {device.dpi} D P I.")
 
     def recapture_mouse(self):
-        """Recapture the mouse device. Triggered by keybind."""
+        """Recapture the mouse device. Triggered by keybind.
+
+        Runs detection on a background thread so it doesn't block the
+        key listener (detect_mouse_device pumps a Win32 message loop
+        for up to DETECTION_TIMEOUT seconds).
+        """
         if self.speaker:
             self.speaker.speak("Move your mouse to detect it.")
 
+        thread = threading.Thread(target=self._recapture_mouse_blocking, daemon=True)
+        thread.start()
+
+    def _recapture_mouse_blocking(self):
+        """Blocking recapture logic — runs on a background thread."""
         # Stop current capture if running
         was_running = self.running
         if was_running:

--- a/lib/utilities/mouse.py
+++ b/lib/utilities/mouse.py
@@ -330,11 +330,13 @@ def get_screen_size():
     user32 = ctypes.windll.user32
     return (user32.GetSystemMetrics(0), user32.GetSystemMetrics(1))
 
-def move_to(target_x, target_y, duration=0.1):
+def move_to(target_x, target_y, duration=0):
     """Move cursor to absolute screen coordinates using FakerInput.
-    Computes the pixel delta from current position, then sends scaled
-    FakerInput relative moves spread over ``duration`` seconds to match
-    pyautogui.MINIMUM_DURATION (0.1s)."""
+
+    duration=0 (default): instant move via a single FakerInput report batch.
+    duration>0: spread the move over ``duration`` seconds for visual smoothness
+                (e.g. player_position auto-turn uses this for in-game camera moves).
+    """
     if not _ensure_init():
         return
     cur_x, cur_y = get_mouse_position()
@@ -364,24 +366,27 @@ def move_to(target_x, target_y, duration=0.1):
         if i < steps - 1 and step_delay > 0:
             time.sleep(step_delay)
 
-def move_to_and_click(target_x, target_y, button='left', duration=0.1, settle=0.1):
-    """Mirrors pyautogui.moveTo(x, y, duration) + pyautogui.click().
-    duration matches pyautogui.MINIMUM_DURATION (0.1s).
-    settle matches pyautogui.PAUSE (0.1s) — the delay after moveTo returns."""
+def move_to_and_click(target_x, target_y, button='left', duration=0, settle=0.02):
+    """Move to coordinates and click.
+
+    duration: time to spread the move over (0 = instant).
+    settle: brief pause after move before click — just enough for the game
+            to register the cursor position (20ms). Set to 0 for maximum speed.
+    """
     move_to(target_x, target_y, duration=duration)
     if settle > 0:
         time.sleep(settle)
     click_mouse(button)
 
-def instant_click(target_x, target_y, button='left', settle=0.1):
-    """Mirrors pyautogui.click(x, y) with PAUSE=0.1 between move and click."""
+def instant_click(target_x, target_y, button='left', settle=0.02):
+    """Instant move + click with minimal settle delay."""
     move_to(target_x, target_y, duration=0)
     if settle > 0:
         time.sleep(settle)
     click_mouse(button)
 
-def move_to_and_right_click(target_x, target_y, duration=0.1, settle=0.1):
-    """Mirrors pyautogui.moveTo(x, y, duration) + pyautogui.rightClick()."""
+def move_to_and_right_click(target_x, target_y, duration=0, settle=0.02):
+    """Move to coordinates and right-click."""
     move_to(target_x, target_y, duration=duration)
     if settle > 0:
         time.sleep(settle)


### PR DESCRIPTION
## Summary
- move_to() default duration 0.1s -> 0 (instant), ~100x faster for UI automation
- move_to_and_click/right_click settle 0.1s -> 0.02s (20ms is enough for the game to register cursor position)
- instant_click settle 0.1s -> 0.02s
- Remove unnecessary duration=0.04 from discovery_gui and gamemode_gui callers
- Mouse passthrough recapture_mouse() and _first_time_setup() now run device detection on background threads instead of blocking the key listener thread for 10 seconds