### PR TITLE
Rework storm detection and fix bloom monitor

### DIFF
--- a/lib/detection/player_position.py
+++ b/lib/detection/player_position.py
@@ -12,7 +12,6 @@ import math
 from typing import Optional, Tuple
 from accessible_output2.outputs.auto import Auto
 from lib.utilities.utilities import read_config, get_config_boolean, get_config_float, get_config_int, on_config_change
-from lib.utilities import perf_profiler
 from lib.managers.screenshot_manager import capture_coordinates, get_pixel
 from lib.detection.dynamic_object_finder import optimized_finder, DYNAMIC_OBJECT_CONFIGS
 from lib.detection.ppi import find_player_position as ppi_find_player_position
@@ -1054,8 +1053,6 @@ class ContinuousPOIPinger:
 
 def start_icon_detection(use_ppi=False):
     """Start icon detection with manual trigger handling"""
-    perf_profiler.start_run("navigation")
-    perf_profiler.mark("start_icon_detection entered")
     config = read_config()
     selected_poi_str = config.get('POI', 'selected_poi', fallback='none,0,0')
     selected_poi_parts = selected_poi_str.split(',')
@@ -1083,33 +1080,23 @@ def start_icon_detection(use_ppi=False):
 
 def icon_detection_cycle(selected_poi_name, use_ppi, play_poi_sound_enabled=True):
     """Icon detection cycle that uses either PPI or original mouse behavior"""
-    perf_profiler.mark("icon_detection_cycle entered")
     if selected_poi_name.lower() == 'none':
         speaker.speak("No POI selected. Please select a POI first.")
-        perf_profiler.end_run()
         return
 
     # Get player info based on method
     if use_ppi:
-        # Use PPI method
-        perf_profiler.mark("get_player_info_ppi start")
         player_location, player_angle = get_player_info_ppi()
-        perf_profiler.mark("get_player_info_ppi end")
         if player_location is None:
             speaker.speak("Could not find player position using PPI")
             play_poi_sound_enabled = False
     else:
-        # Use original icon detection method
-        perf_profiler.mark("find_player_icon start")
         player_location, player_angle = find_player_icon_location_with_direction()
-        perf_profiler.mark("find_player_icon end")
         if player_location is None:
             speaker.speak("Could not find player position using icon detection")
             play_poi_sound_enabled = False
 
-    perf_profiler.mark("handle_poi_selection start")
     poi_data_tuple = handle_poi_selection(selected_poi_name, player_location, use_ppi)
-    perf_profiler.mark("handle_poi_selection end")
     
     poi_name_resolved, poi_coords_resolved = poi_data_tuple
     # Fallback: if resolution failed, try using saved coordinates from config
@@ -1131,9 +1118,7 @@ def icon_detection_cycle(selected_poi_name, use_ppi, play_poi_sound_enabled=True
 
     # Play spatial sound if enabled
     if play_poi_sound_enabled and player_location is not None and player_angle is not None:
-        perf_profiler.mark("play_spatial_poi_sound start")
         play_spatial_poi_sound(player_location, player_angle, poi_coords_resolved)
-        perf_profiler.mark("play_spatial_poi_sound end")
 
     # Handle mouse actions based on method
     if not use_ppi:
@@ -1148,16 +1133,13 @@ def icon_detection_cycle(selected_poi_name, use_ppi, play_poi_sound_enabled=True
             move_to(poi_coords_resolved[0], poi_coords_resolved[1])
 
     # Perform POI actions
-    perf_profiler.mark("perform_poi_actions start")
     perform_poi_actions(poi_data_tuple, player_location, speak_info=False, use_ppi=use_ppi)
-    perf_profiler.mark("perform_poi_actions end")
 
     config = read_config()
     auto_turn_enabled = get_config_boolean(config, 'AutoTurn', False)
     auto_turn_success = False
     
     if auto_turn_enabled:
-        perf_profiler.mark("auto_turn start")
         if not use_ppi:
             pyautogui.press('escape')
             time.sleep(0.1)
@@ -1165,10 +1147,8 @@ def icon_detection_cycle(selected_poi_name, use_ppi, play_poi_sound_enabled=True
             auto_turn_success = auto_turn_towards_poi(player_location, poi_coords_resolved, poi_name_resolved)
         else:
             speaker.speak("Cannot auto-turn, player location unknown.")
-        perf_profiler.mark("auto_turn end")
 
     # Get final angle for speech
-    perf_profiler.mark("get_final_angle start")
     if use_ppi:
         _, latest_player_angle = get_player_info_ppi()
     else:
@@ -1177,12 +1157,8 @@ def icon_detection_cycle(selected_poi_name, use_ppi, play_poi_sound_enabled=True
     final_direction_source, final_angle_for_speech = find_minimap_icon_direction()
     if final_angle_for_speech is None:
         final_angle_for_speech = latest_player_angle if latest_player_angle is not None else player_angle
-    perf_profiler.mark("get_final_angle end")
 
-    perf_profiler.mark("speak_result start")
     speak_auto_turn_result(poi_name_resolved, player_location, final_angle_for_speech, poi_coords_resolved, auto_turn_enabled, auto_turn_success)
-    perf_profiler.mark("speak_result end")
-    perf_profiler.end_run()
 
 def speak_auto_turn_result(poi_name, player_location, player_angle, poi_location, auto_turn_enabled, success):
     """Speak auto-turn result"""
@@ -1270,11 +1246,9 @@ def describe_player_position(poi_name=None, poi_location=None):
 def get_player_info_ppi():
     """Get player location and angle using PPI method"""
     # Try to use cached position first for performance
-    perf_profiler.mark("  ppi: check cache")
     cached_pos, cached_angle = position_tracker.get_position_and_angle(force_update=True)
 
     if cached_pos is not None and cached_angle is not None:
-        perf_profiler.mark("  ppi: cache hit")
         return cached_pos, cached_angle
 
     # Use PPI for position detection
@@ -1282,17 +1256,12 @@ def get_player_info_ppi():
     player_angle = None
 
     # Always try PPI regardless of map check
-    perf_profiler.mark("  ppi: find_player_position start")
     player_location = ppi_find_player_position()
-    perf_profiler.mark("  ppi: find_player_position end")
     if player_location is not None:
-        perf_profiler.mark("  ppi: find_minimap_direction start")
         _, player_angle = find_minimap_icon_direction()
-        perf_profiler.mark("  ppi: find_minimap_direction end")
 
     # Always try to get angle from minimap if we don't have it
     if player_angle is None:
-        perf_profiler.mark("  ppi: minimap_direction fallback")
         _, player_angle_fallback = find_minimap_icon_direction()
         if player_angle_fallback is not None:
             player_angle = player_angle_fallback

--- a/lib/detection/ppi.py
+++ b/lib/detection/ppi.py
@@ -8,7 +8,6 @@ import os
 from typing import Optional, Tuple
 from lib.managers.screenshot_manager import capture_region
 from lib.utilities.utilities import read_config, on_config_change
-from lib.utilities import perf_profiler
 
 # Check if OpenCL is available and enable it. OpenCV's T-API will handle the rest.
 use_gpu = cv2.ocl.haveOpenCL()
@@ -128,6 +127,10 @@ class MapManager:
 # Global map manager instance
 map_manager = MapManager()
 
+# Last matched region (4 corners on map image) — used by storm monitor for scale
+last_matched_region = None
+
+
 def capture_map_screen(map_name: str = "main"):
     """Capture the map area of the screen using appropriate coordinates for the map"""
     region = get_ppi_coordinates(map_name)
@@ -135,8 +138,6 @@ def capture_map_screen(map_name: str = "main"):
 
 def _match_at_scale(captured_area, scale_factor=1):
     """Core matching logic. scale_factor > 1 means capture was downscaled."""
-    scale_label = f"{scale_factor}x" if scale_factor > 1 else "full"
-    perf_profiler.mark(f"    ppi._match_at_scale({scale_label}): start")
     if scale_factor > 1:
         small = cv2.resize(captured_area,
                            (captured_area.shape[1] // scale_factor,
@@ -144,13 +145,11 @@ def _match_at_scale(captured_area, scale_factor=1):
     else:
         small = captured_area
 
-    perf_profiler.mark(f"    ppi._match_at_scale({scale_label}): SIFT detect")
     kp1, des1 = map_manager.sift.detectAndCompute(small, None)
 
     if des1 is None or map_manager.current_descriptors is None:
         return None
 
-    perf_profiler.mark(f"    ppi._match_at_scale({scale_label}): knnMatch")
     matches = map_manager.bf.knnMatch(des1, map_manager.current_descriptors, k=2)
 
     good_matches = []
@@ -159,8 +158,6 @@ def _match_at_scale(captured_area, scale_factor=1):
             m, n = match_pair
             if m.distance < 0.75 * n.distance:
                 good_matches.append(m)
-
-    perf_profiler.mark(f"    ppi._match_at_scale({scale_label}): ratio test ({len(good_matches)} good)")
 
     MIN_MATCHES = 25
     if len(good_matches) <= MIN_MATCHES:
@@ -228,13 +225,12 @@ def find_player_position() -> Optional[Tuple[int, int]]:
     roi_width = roi_end[0] - roi_start[0]
     roi_height = roi_end[1] - roi_start[1]
 
-    perf_profiler.mark("    ppi: capture_map_screen")
     captured_area = capture_map_screen(map_filename_to_load)
-    perf_profiler.mark("    ppi: find_best_match start")
     matched_region = find_best_match(captured_area)
-    perf_profiler.mark("    ppi: find_best_match end")
 
+    global last_matched_region
     if matched_region is not None:
+        last_matched_region = matched_region
         center = np.mean(matched_region, axis=0).reshape(-1)
 
         map_h, map_w = map_manager.current_image_dims

--- a/lib/monitors/bloom_monitor.py
+++ b/lib/monitors/bloom_monitor.py
@@ -5,7 +5,7 @@ Detects bloom lines radiating from screen center and plays a pitch-shifted
 440 Hz tone that increases as bloom grows. Also detects pickaxe equip via
 center pixel pattern.
 
-Runs at 24 FPS, scanning a 150x150 region around screen center (960, 540).
+Runs at 10 FPS, scanning a 300x300 region around screen center (960, 540).
 """
 
 import threading
@@ -37,8 +37,8 @@ MAX_BLOOM_DIST = 65
 TONE_VOLUME = 0.25
 TONE_COOLDOWN = 0.05  # Minimum seconds between tone plays
 
-# Frame interval for 24 FPS
-FRAME_INTERVAL = 1.0 / 24.0
+# Frame interval for 10 FPS (24 FPS caused noticeable lag from screenshot overhead)
+FRAME_INTERVAL = 1.0 / 10.0
 
 
 def _color_match(pixel, target, tol=COLOR_TOLERANCE):
@@ -81,6 +81,13 @@ class BloomMonitor:
         # Audio - use engine directly for fire-and-forget playback
         self._sound_id = 'sounds/bloom_tone.ogg'
         self._audio_loaded = False
+
+        # Read actual config on init (before any change events fire)
+        try:
+            config = read_config()
+            self._cached_enabled = get_config_boolean(config, 'MonitorBloom', True)
+        except Exception:
+            pass
 
         on_config_change(self._on_config_change)
 

--- a/lib/monitors/storm_monitor.py
+++ b/lib/monitors/storm_monitor.py
@@ -1,6 +1,8 @@
 """
-Minimap-based storm detection using purple tint detection
-Detects pixels with abnormal purple coloring compared to normal terrain
+Minimap-based storm detection using PPI-aligned reference comparison.
+Uses PPI's feature matching to determine exactly what area of the map
+is visible on the minimap, crops and resizes the reference map to match,
+then compares pixel-by-pixel to detect the storm overlay.
 """
 
 import threading
@@ -10,13 +12,22 @@ import numpy as np
 import cv2
 from typing import Optional, Tuple
 from accessible_output2.outputs.auto import Auto
-from lib.utilities.utilities import read_config, get_config_boolean, get_config_float, calculate_distance, process_minimap, get_minimap_region, on_config_change
-
-# Minimap region is now loaded dynamically via get_minimap_region()
+from lib.utilities.utilities import read_config, get_config_boolean, get_config_float, calculate_distance, get_minimap_region, on_config_change
+from lib.managers.screenshot_manager import capture_region
 
 from lib.monitors.background_monitor import monitor
-from lib.detection.player_position import find_player_position, find_minimap_icon_direction
+from lib.detection import ppi as ppi_module
+from lib.detection.ppi import PPI_CAPTURE_REGION, PPI_CAPTURE_REGION_LEGACY
 from lib.utilities.spatial_audio import SpatialAudio
+
+def _get_position_tracker():
+    from lib.detection.player_position import position_tracker
+    return position_tracker
+
+def _get_find_minimap_icon_direction():
+    from lib.detection.player_position import find_minimap_icon_direction
+    return find_minimap_icon_direction
+
 
 class StormAudioThread:
     """Manages audio for storm with configurable ping intervals"""
@@ -31,24 +42,20 @@ class StormAudioThread:
         self.position_lock = threading.Lock()
 
     def start(self, position: Tuple[int, int], distance: float):
-        """Start the audio thread"""
         with self.position_lock:
             self.current_position = position
             self.current_distance = distance
-
         if not self.thread or not self.thread.is_alive():
             self.stop_event.clear()
             self.thread = threading.Thread(target=self._audio_loop, daemon=True)
             self.thread.start()
 
     def update_position(self, position: Tuple[int, int], distance: float):
-        """Update the storm's position and distance"""
         with self.position_lock:
             self.current_position = position
             self.current_distance = distance
 
     def stop(self):
-        """Stop the audio thread"""
         self.stop_event.set()
         if self.audio_instance:
             try:
@@ -59,79 +66,84 @@ class StormAudioThread:
             self.thread.join(timeout=1.0)
 
     def _audio_loop(self):
-        """Main audio loop that plays pings at configured intervals"""
         while not self.stop_event.is_set():
             try:
                 with self.position_lock:
                     position = self.current_position
                     distance = self.current_distance
-
                 if position and distance is not None:
-                    _, player_angle = find_minimap_icon_direction()
+                    _, player_angle = _get_find_minimap_icon_direction()()
                     if player_angle is not None:
-                        player_pos = find_player_position()
+                        player_pos = _get_position_tracker().get_cached_position()
                         if player_pos:
                             self._play_spatial_audio(player_pos, player_angle, position, distance)
-
                 if self.stop_event.wait(timeout=self.ping_interval):
                     break
-
             except Exception:
                 time.sleep(0.1)
 
-    def _play_spatial_audio(self, player_pos: Tuple[int, int], player_angle: float,
-                           storm_pos: Tuple[int, int], distance: float):
-        """Play spatial audio for the storm"""
+    def _play_spatial_audio(self, player_pos, player_angle, storm_pos, distance):
         if not self.audio_instance:
             return
         try:
             distance, relative_angle = SpatialAudio.calculate_distance_and_angle(
                 player_pos, player_angle, storm_pos
             )
-
             max_distance = 300.0
             distance_factor = min(distance / max_distance, 1.0)
             volume_factor = (1.0 - distance_factor) ** 1.5
             final_volume = self.volume * volume_factor
             final_volume = np.clip(final_volume, 0.1, self.volume)
-
-            self.audio_instance.play_audio(
-                distance=distance,
-                relative_angle=relative_angle,
-                volume=final_volume
-            )
-
+            self.audio_instance.play_audio(distance=distance, relative_angle=relative_angle, volume=final_volume)
         except Exception:
             pass
 
+
 class StormMonitor:
-    """Minimap-based storm monitor using purple tint detection"""
+    """Minimap-based storm monitor using PPI-aligned reference comparison"""
     def __init__(self):
         self.speaker = Auto()
         self.running = False
         self.stop_event = threading.Event()
         self.detection_thread = None
 
-        self.min_contour_area = 1000
+        self.min_contour_area = 3000
         self.minimap_scale_factor = 0.5
 
         self.storm_audio = None
         self.active_audio_thread = None
-        self.detection_interval = 1.7
+        self.detection_interval = 0.5
 
-        # Cached config values — updated via on_config_change
+        # Color reference map (cached per map)
+        self._color_ref = None
+        self._color_ref_name = None
+
+        # Cached config values
         self._cached_enabled = True
         self._cached_storm_volume = 0.5
         self._cached_ping_interval = 1.5
+        self._cached_current_map = 'main'
 
         self.initialize_audio()
+        self._init_cached_config()
         on_config_change(self._on_config_change)
 
+    def _init_cached_config(self):
+        try:
+            config = read_config()
+            self._cached_current_map = config.get('POI', 'current_map', fallback='main')
+        except Exception:
+            pass
+
     def _on_config_change(self, config):
-        """Handle config change event."""
         self._cached_enabled = get_config_boolean(config, 'MonitorStorm', True)
         self._cached_storm_volume = get_config_float(config, 'StormVolume', 0.5)
         self._cached_ping_interval = get_config_float(config, 'StormPingInterval', 1.5)
+        new_map = config.get('POI', 'current_map', fallback='main')
+        if new_map != self._cached_current_map:
+            self._cached_current_map = new_map
+            self._color_ref = None
+            self._color_ref_name = None
         if self.storm_audio:
             master_volume, storm_volume = SpatialAudio.get_volume_from_config(
                 config, 'StormVolume', 'MasterVolume', 0.5
@@ -140,7 +152,6 @@ class StormMonitor:
             self.storm_audio.set_individual_volume(storm_volume)
 
     def initialize_audio(self):
-        """Initialize storm audio"""
         storm_sound_path = 'sounds/storm.ogg'
         if os.path.exists(storm_sound_path):
             try:
@@ -155,112 +166,275 @@ class StormMonitor:
                 self.storm_audio = None
 
     def is_enabled(self) -> bool:
-        """Check if storm monitoring is enabled in config"""
         return self._cached_enabled
 
     def should_monitor(self) -> bool:
-        """Check if monitoring should be active"""
         return self.is_enabled() and not monitor.map_open
 
     def get_storm_volume(self) -> float:
-        """Get storm volume from config"""
         return self._cached_storm_volume
 
     def get_storm_ping_interval(self) -> float:
-        """Get storm ping interval from config"""
         return self._cached_ping_interval
 
-    def detect_purple_tint(self, screenshot: np.ndarray) -> np.ndarray:
+    # ── Reference map ───────────────────────────────────────────────
+
+    def _get_color_ref(self) -> Optional[np.ndarray]:
+        """Load and cache the reference map image in RGB."""
+        name = self._cached_current_map
+        if self._color_ref is not None and self._color_ref_name == name:
+            return self._color_ref
+        path = f"maps/{name}.png"
+        if not os.path.exists(path):
+            return None
+        bgr = cv2.imread(path, cv2.IMREAD_COLOR)
+        if bgr is None:
+            return None
+        self._color_ref = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+        self._color_ref_name = name
+        return self._color_ref
+
+    def _get_ppi_capture_region(self) -> dict:
+        """Get the PPI capture region for the current map."""
+        if self._cached_current_map == "o g":
+            return PPI_CAPTURE_REGION_LEGACY
+        return PPI_CAPTURE_REGION
+
+    # ── Alignment via PPI matched region ────────────────────────────
+
+    def _get_ref_aligned(self, screenshot: np.ndarray) -> Optional[np.ndarray]:
         """
-        Detect pixels with abnormal purple tint.
-        Purple tint means elevated red AND blue channels relative to green.
+        Use PPI's last matched region to crop and resize the reference map
+        so it aligns pixel-for-pixel with the live minimap capture.
         """
-        screenshot_float = screenshot.astype(np.float32)
-        
-        r = screenshot_float[:, :, 0]
-        g = screenshot_float[:, :, 1]
-        b = screenshot_float[:, :, 2]
-        
-        red_over_green = r / (g + 1)
-        blue_over_green = b / (g + 1)
-        
-        red_threshold = 1.3
-        blue_threshold = 1.3
-        
-        rb_ratio = np.minimum(r, b) / (np.maximum(r, b) + 1)
-        balance_threshold = 0.6
-        
-        brightness = (r + g + b) / 3
-        brightness_mask = (brightness > 30) & (brightness < 240)
-        
-        purple_mask = (
-            (red_over_green > red_threshold) &
-            (blue_over_green > blue_threshold) &
-            (rb_ratio > balance_threshold) &
-            brightness_mask
-        ).astype(np.uint8) * 255
-        
+        ref_map = self._get_color_ref()
+        if ref_map is None:
+            return None
+
+        matched = ppi_module.last_matched_region
+        if matched is None:
+            return None
+
+        pts = matched.reshape(4, 2)  # 4 corners on map image
+
+        # Center of matched quad = player position on map image
+        center_x, center_y = np.mean(pts, axis=0)
+
+        # Size of quad = how much of the map image the minimap covers
+        # pts order: [top-left, bottom-left, bottom-right, top-right]
+        quad_w = (np.linalg.norm(pts[3] - pts[0]) + np.linalg.norm(pts[2] - pts[1])) / 2
+        quad_h = (np.linalg.norm(pts[1] - pts[0]) + np.linalg.norm(pts[2] - pts[3])) / 2
+
+        if quad_w < 10 or quad_h < 10:
+            return None
+
+        map_h, map_w = ref_map.shape[:2]
+        cap_h, cap_w = screenshot.shape[:2]
+
+        # Crop reference map centered on player, sized to the matched quad
+        hw = int(quad_w / 2)
+        hh = int(quad_h / 2)
+        cx = int(center_x)
+        cy = int(center_y)
+
+        # Clamp + pad for edges
+        x1, y1 = cx - hw, cy - hh
+        x2, y2 = cx + hw, cy + hh
+
+        pad_left = max(0, -x1)
+        pad_top = max(0, -y1)
+        pad_right = max(0, x2 - map_w)
+        pad_bottom = max(0, y2 - map_h)
+
+        cx1 = max(0, x1)
+        cy1 = max(0, y1)
+        cx2 = min(map_w, x2)
+        cy2 = min(map_h, y2)
+
+        ref_crop = ref_map[cy1:cy2, cx1:cx2]
+        if ref_crop.size == 0:
+            return None
+
+        if pad_left or pad_top or pad_right or pad_bottom:
+            ref_crop = cv2.copyMakeBorder(
+                ref_crop, pad_top, pad_bottom, pad_left, pad_right,
+                cv2.BORDER_CONSTANT, value=(0, 0, 0)
+            )
+
+        # Resize to match the minimap capture dimensions
+        return cv2.resize(ref_crop, (cap_w, cap_h), interpolation=cv2.INTER_LINEAR)
+
+    # ── Storm detection ─────────────────────────────────────────────
+
+    def detect_storm_mask(self, screenshot: np.ndarray, ref_aligned: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Compare live minimap vs aligned reference to detect the storm overlay.
+        Returns (storm_mask, purple_shift).
+        """
+        live = screenshot.astype(np.float32)
+        ref = ref_aligned.astype(np.float32)
+        diff = live - ref
+
+        r_shift = diff[:, :, 0]
+        g_shift = diff[:, :, 1]
+        b_shift = diff[:, :, 2]
+
+        # Storm overlay adds purple tint: R and B increase, G relatively less
+        purple_shift = ((r_shift + b_shift) * 0.5) - g_shift
+        storm_mask = (purple_shift > 50).astype(np.uint8) * 255
+
+        # Morphological cleanup
         kernel_small = np.ones((3, 3), np.uint8)
-        purple_mask = cv2.morphologyEx(purple_mask, cv2.MORPH_CLOSE, kernel_small)
-        purple_mask = cv2.morphologyEx(purple_mask, cv2.MORPH_OPEN, kernel_small)
-        
+        storm_mask = cv2.morphologyEx(storm_mask, cv2.MORPH_CLOSE, kernel_small)
+        storm_mask = cv2.morphologyEx(storm_mask, cv2.MORPH_OPEN, kernel_small)
+
         kernel_large = np.ones((15, 15), np.uint8)
-        purple_mask = cv2.morphologyEx(purple_mask, cv2.MORPH_CLOSE, kernel_large)
-        
-        return purple_mask
+        storm_mask = cv2.morphologyEx(storm_mask, cv2.MORPH_CLOSE, kernel_large)
+
+        return storm_mask, purple_shift
+
+    # ── Debug output ────────────────────────────────────────────────
+
+    def _save_debug_image(self, screenshot: np.ndarray, ref_aligned,
+                          purple_shift, mask,
+                          contour=None, closest_point=None):
+        """TEMPORARY: Save debug image every tick."""
+        try:
+            h, w = screenshot.shape[:2]
+            center = (w // 2, h // 2)
+            font = cv2.FONT_HERSHEY_SIMPLEX
+            has_ref = ref_aligned is not None
+
+            # Panel 1: Live minimap
+            live_bgr = cv2.cvtColor(screenshot, cv2.COLOR_RGB2BGR)
+
+            # Panel 2: Aligned reference (or placeholder)
+            if has_ref:
+                ref_bgr = cv2.cvtColor(ref_aligned, cv2.COLOR_RGB2BGR)
+            else:
+                ref_bgr = np.zeros_like(live_bgr)
+                cv2.putText(ref_bgr, "Waiting for PPI match...", (10, h // 2), font, 0.4, (100, 100, 100), 1)
+
+            # Panel 3: Difference (amplified)
+            if has_ref:
+                abs_diff = np.abs(screenshot.astype(np.float32) - ref_aligned.astype(np.float32))
+                diff_vis = np.clip(abs_diff * 3, 0, 255).astype(np.uint8)
+                diff_bgr = cv2.cvtColor(diff_vis, cv2.COLOR_RGB2BGR)
+            else:
+                diff_bgr = np.zeros_like(live_bgr)
+
+            # Panel 4: Storm overlay on live
+            overlay = cv2.cvtColor(screenshot, cv2.COLOR_RGB2BGR)
+            if mask is not None and np.any(mask > 0):
+                storm_layer = np.zeros_like(overlay)
+                storm_layer[mask > 0] = (180, 50, 180)
+                overlay = cv2.addWeighted(overlay, 0.6, storm_layer, 0.4, 0)
+            if contour is not None:
+                cv2.drawContours(overlay, [contour], -1, (0, 255, 0), 2)
+            if closest_point is not None:
+                cv2.circle(overlay, tuple(closest_point), 5, (0, 0, 255), -1)
+                cv2.line(overlay, center, tuple(closest_point), (0, 0, 255), 2)
+            cv2.circle(overlay, center, 4, (255, 255, 0), -1)
+
+            # Grid
+            top_row = np.hstack([live_bgr, ref_bgr])
+            bot_row = np.hstack([diff_bgr, overlay])
+            grid = np.vstack([top_row, bot_row])
+
+            labels = ["Live (PPI region)", "Aligned Reference", "Difference (x3)", "Storm Overlay"]
+            for i, label in enumerate(labels):
+                cv2.putText(grid, label, ((i % 2) * w + 5, (i // 2) * h + 20),
+                            font, 0.5, (255, 255, 255), 1, cv2.LINE_AA)
+
+            # Stats bar
+            text_bar = np.zeros((60, grid.shape[1], 3), dtype=np.uint8)
+            storm_count = int(np.sum(mask > 0)) if mask is not None else 0
+
+            # Scale info from PPI
+            matched = ppi_module.last_matched_region
+            scale_str = "N/A"
+            if matched is not None:
+                pts = matched.reshape(4, 2)
+                qw = (np.linalg.norm(pts[3] - pts[0]) + np.linalg.norm(pts[2] - pts[1])) / 2
+                scale_str = f"{qw / w:.2f}"
+
+            cv2.putText(text_bar,
+                        f"Storm: {storm_count}px  Scale: {scale_str}  Map: {self._cached_current_map}",
+                        (5, 18), font, 0.4, (200, 200, 200), 1, cv2.LINE_AA)
+
+            if purple_shift is not None and storm_count > 0:
+                sv = purple_shift[mask > 0]
+                cv2.putText(text_bar,
+                            f"Purple shift (storm): mean={np.mean(sv):.1f} min={np.min(sv):.1f} max={np.max(sv):.1f}",
+                            (5, 38), font, 0.35, (180, 180, 255), 1, cv2.LINE_AA)
+            elif purple_shift is not None:
+                cv2.putText(text_bar,
+                            f"Purple shift (all): mean={np.mean(purple_shift):.1f} min={np.min(purple_shift):.1f} max={np.max(purple_shift):.1f}",
+                            (5, 38), font, 0.35, (200, 200, 200), 1, cv2.LINE_AA)
+
+            final = np.vstack([grid, text_bar])
+            debug_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'storm_debug.png')
+            cv2.imwrite(os.path.abspath(debug_path), final)
+        except Exception as e:
+            print(f"[storm debug] Failed to save debug image: {e}")
+
+    # ── Main detection ──────────────────────────────────────────────
 
     def detect_storm_on_minimap(self) -> Optional[Tuple[int, int]]:
-        """
-        Detects the storm on the minimap by finding purple-tinted pixels
-        and returns the closest point on the storm's edge.
-        """
+        """Detect storm using PPI-aligned reference comparison."""
         try:
-            screenshot = process_minimap()
+            # Capture from the SAME region PPI uses
+            ppi_region = self._get_ppi_capture_region()
+            screenshot = capture_region(ppi_region, 'rgb')
             if screenshot is None:
                 return None
 
-            mask = self.detect_purple_tint(screenshot)
-            
-            contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            # Get aligned reference
+            ref_aligned = self._get_ref_aligned(screenshot)
 
-            if not contours:
-                return None
+            mask = None
+            purple_shift = None
+            storm_contour = None
+            closest_point = None
+            result = None
 
-            storm_contour = max(contours, key=cv2.contourArea)
-            if cv2.contourArea(storm_contour) < self.min_contour_area:
-                return None
+            if ref_aligned is not None:
+                mask, purple_shift = self.detect_storm_mask(screenshot, ref_aligned)
 
-            h, w = mask.shape
-            player_minimap_point = (w // 2, h // 2)
+                contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+                if contours:
+                    storm_contour = max(contours, key=cv2.contourArea)
+                    if cv2.contourArea(storm_contour) >= self.min_contour_area:
+                        h, w = mask.shape
+                        mm_cx, mm_cy = w // 2, h // 2
+                        contour_points = storm_contour.reshape(-1, 2)
+                        edge_mask = (
+                            (contour_points[:, 0] > 1) & (contour_points[:, 0] < w - 2) &
+                            (contour_points[:, 1] > 1) & (contour_points[:, 1] < h - 2)
+                        )
+                        safe_pts = contour_points[edge_mask]
+                        if len(safe_pts) == 0:
+                            safe_pts = contour_points
+                        if len(safe_pts) > 0:
+                            center = np.array((mm_cx, mm_cy))
+                            dists = np.linalg.norm(safe_pts - center, axis=1)
+                            closest_point = safe_pts[np.argmin(dists)]
+                            result = (int(closest_point[0] + ppi_region['left']),
+                                      int(closest_point[1] + ppi_region['top']))
+                    else:
+                        storm_contour = None
 
-            contour_points = storm_contour.reshape(-1, 2)
-            
-            edge_mask = (
-                (contour_points[:, 0] > 1) & (contour_points[:, 0] < w - 2) &
-                (contour_points[:, 1] > 1) & (contour_points[:, 1] < h - 2)
-            )
-            safe_edge_points = contour_points[edge_mask]
-            
-            if len(safe_edge_points) == 0:
-                safe_edge_points = contour_points
-            
-            if len(safe_edge_points) == 0:
-                return None
+            # TEMPORARY: Always save debug
+            self._save_debug_image(screenshot, ref_aligned, purple_shift, mask,
+                                   storm_contour, closest_point)
 
-            dists = np.linalg.norm(safe_edge_points - np.array(player_minimap_point), axis=1)
-            closest_point_on_minimap = safe_edge_points[np.argmin(dists)]
-
-            minimap_region = get_minimap_region()
-            screen_x = int(closest_point_on_minimap[0] + minimap_region['left'])
-            screen_y = int(closest_point_on_minimap[1] + minimap_region['top'])
-            
-            return (screen_x, screen_y)
-        except Exception:
+            return result
+        except Exception as e:
+            print(f"[storm] detect error: {e}")
             return None
 
     def convert_minimap_to_fullmap_coords(self, minimap_coords: Tuple[int, int],
                                         player_fullmap_pos: Tuple[int, int]) -> Tuple[int, int]:
-        """Convert minimap coordinates to full map coordinates"""
         minimap_x, minimap_y = minimap_coords
         player_fullmap_x, player_fullmap_y = player_fullmap_pos
         minimap_region = get_minimap_region()
@@ -272,8 +446,9 @@ class StormMonitor:
         fullmap_y = int(player_fullmap_y + (offset_y * self.minimap_scale_factor))
         return (fullmap_x, fullmap_y)
 
+    # ── Loop & lifecycle ────────────────────────────────────────────
+
     def detection_loop(self):
-        """Main detection loop"""
         last_detection_time = 0
         while not self.stop_event.is_set():
             try:
@@ -285,7 +460,7 @@ class StormMonitor:
                 if current_time - last_detection_time >= self.detection_interval:
                     storm_minimap_coords = self.detect_storm_on_minimap()
                     if storm_minimap_coords:
-                        player_fullmap_pos = find_player_position()
+                        player_fullmap_pos = _get_position_tracker().get_cached_position()
                         if player_fullmap_pos:
                             storm_fullmap_coords = self.convert_minimap_to_fullmap_coords(
                                 storm_minimap_coords, player_fullmap_pos
@@ -304,23 +479,21 @@ class StormMonitor:
                     else:
                         self.cleanup_audio_thread()
                     last_detection_time = current_time
-                time.sleep(1.0)
+                time.sleep(0.1)
             except Exception:
                 time.sleep(2.0)
 
     def cleanup_audio_thread(self):
-        """Stop and clean up audio thread"""
         if self.active_audio_thread:
             self.active_audio_thread.stop()
             self.active_audio_thread = None
 
     def get_current_storm_location(self) -> Optional[Tuple[int, int]]:
-        """Get current storm location for POI usage"""
         if not self.is_enabled():
             return None
         storm_minimap_coords = self.detect_storm_on_minimap()
         if storm_minimap_coords:
-            player_fullmap_pos = find_player_position()
+            player_fullmap_pos = _get_position_tracker().get_cached_position()
             if player_fullmap_pos:
                 return self.convert_minimap_to_fullmap_coords(
                     storm_minimap_coords, player_fullmap_pos
@@ -328,15 +501,19 @@ class StormMonitor:
         return None
 
     def start_monitoring(self):
-        """Start storm monitoring"""
         if not self.running:
             self.running = True
             self.stop_event.clear()
+            try:
+                tracker = _get_position_tracker()
+                if not tracker.monitoring:
+                    tracker.start_monitoring()
+            except Exception:
+                pass
             self.detection_thread = threading.Thread(target=self.detection_loop, daemon=True)
             self.detection_thread.start()
 
     def stop_monitoring(self):
-        """Stop storm monitoring"""
         self.stop_event.set()
         self.running = False
         self.cleanup_audio_thread()


### PR DESCRIPTION
## Summary
- **Storm detection rework**: Replace absolute purple tint detection with PPI-aligned reference map comparison. Uses PPI's feature-matched region to determine exact scale/position, crops the reference map to align pixel-for-pixel with the live minimap, then detects the storm overlay via per-pixel color difference. Includes temp debug output (`storm_debug.png`) for threshold tuning.
- **Remove perf_profiler**: Remove all `perf_profiler` imports and calls from `player_position.py` and `ppi.py` — the module was causing import errors.
- **Fix bloom config**: Bloom monitor was ignoring `MonitorBloom = false` because it hardcoded `_cached_enabled = True` on init. Now reads config at startup.
- **Fix bloom lag**: Reduce bloom monitor from 24 FPS to 10 FPS — 24 captures/sec of a 300×300 region caused noticeable lag.