### PR TITLE
Fix ranked mode display and deduplicate Epic gamemodes

### DIFF
--- a/lib/guis/social_gui.py
+++ b/lib/guis/social_gui.py
@@ -172,8 +172,7 @@ class SocialDialog(AccessibleDialog):
     def _get_ranked_mode_name(self, ranking_type: str) -> str:
         """Get friendly name for ranked mode"""
         mode_names = {
-            'ranked-br': 'Battle Royale',
-            'ranked-zb': 'Zero Build',
+            'ranked-br-combined': 'Battle Royale',
             'ranked_blastberry_build': 'Reload',
             'ranked_blastberry_nobuild': 'Reload Zero Build',
             'ranked-figment-build': 'OG',
@@ -302,7 +301,7 @@ class SocialDialog(AccessibleDialog):
                 ranked_lines.append("Play ranked matches to see your progress here.")
             else:
                 # Show each ranked mode with current rank and progress
-                for ranking_type in ['ranked-br', 'ranked-zb', 'ranked_blastberry_build',
+                for ranking_type in ['ranked-br-combined', 'ranked_blastberry_build',
                                       'ranked_blastberry_nobuild', 'ranked-figment-build', 'ranked-figment-nobuild',
                                       'ranked-squareclub']:
                     if ranking_type in ranked_data:

--- a/lib/managers/social_manager.py
+++ b/lib/managers/social_manager.py
@@ -362,12 +362,12 @@ class SocialManager:
     def _get_ranked_mode_name(self, ranking_type: str) -> str:
         """Get friendly name for ranked mode"""
         mode_names = {
-            'ranked-br': 'Battle Royale',
-            'ranked-zb': 'Zero Build',
+            'ranked-br-combined': 'Battle Royale',
             'ranked_blastberry_build': 'Reload',
             'ranked_blastberry_nobuild': 'Reload Zero Build',
             'ranked-figment-build': 'OG',
-            'ranked-figment-nobuild': 'OG Zero Build'
+            'ranked-figment-nobuild': 'OG Zero Build',
+            'ranked-squareclub': 'Arena Box Fights'
         }
         return mode_names.get(ranking_type, ranking_type)
 

--- a/lib/utilities/epic_auth.py
+++ b/lib/utilities/epic_auth.py
@@ -863,8 +863,7 @@ class EpicAuth:
 
             # Ranking types to query (excluding Ballistic, Rocket Racing, Getaway)
             ranking_types = [
-                'ranked-br',                    # Battle Royale Build
-                'ranked-zb',                    # Battle Royale Zero Build
+                'ranked-br-combined',           # Battle Royale (Build + Zero Build combined)
                 'ranked_blastberry_build',      # Reload Build
                 'ranked_blastberry_nobuild',    # Reload Zero Build
                 'ranked-figment-build',         # OG Build

--- a/lib/utilities/epic_discovery.py
+++ b/lib/utilities/epic_discovery.py
@@ -521,6 +521,15 @@ class EpicDiscovery:
                         except Exception as e:
                             logger.error(f"Error fetching page {page_num}: {e}")
 
+                # Deduplicate by link_code (pages may return overlapping results)
+                seen_codes = set()
+                unique_islands = []
+                for island in islands:
+                    if island.link_code not in seen_codes:
+                        seen_codes.add(island.link_code)
+                        unique_islands.append(island)
+                islands = unique_islands
+
                 # Sort by player count (descending)
                 islands.sort(key=lambda x: x.global_ccu, reverse=True)
                 islands = islands[:limit]


### PR DESCRIPTION
## Summary
- **BR Combined:** Replace separate `ranked-br` + `ranked-zb` API types with `ranked-br-combined` (Epic merged them into a single ranking type)
- **Arena Box Fights announcements:** Add missing `ranked-squareclub` → "Arena Box Fights" mapping in `social_manager.py` so rank change TTS says "Arena Box Fights ranked" instead of "ranked-squareclub ranked"
- **Epic gamemodes dedup:** Fix triple-duplicate results in Discovery GUI's Epic Games tab — `scrape_creator_maps()` fetches 3 pages but fortnite.gg returns the same page 1 for nonexistent pages 2/3; added deduplication by island code

## Test plan
- [ ] Open social GUI → Me tab → verify Battle Royale ranked stats appear under the combined entry
- [ ] Play a ranked match and verify rank change announcements say the correct mode name
- [ ] Open Discovery GUI → Epic Gamemodes tab → verify no duplicate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)