### PR TITLE
Handle 2026-04-16 rank ladder expansion (Elite/Champion split into I/II/III)

### DIFF
--- a/lib/guis/social_gui.py
+++ b/lib/guis/social_gui.py
@@ -5,6 +5,8 @@ Provides interface for managing friends, party, and requests
 import logging
 import wx
 import threading
+from datetime import datetime, timezone
+from typing import Optional
 from lib.utilities.mouse import instant_click
 from accessible_output2.outputs.auto import Auto
 
@@ -16,6 +18,29 @@ from lib.utilities.epic_social import Friend, FriendRequest, PartyMember, PartyI
 
 logger = logging.getLogger(__name__)
 speaker = Auto()
+
+
+# Fortnite's 2026-04-16 rank expansion split Elite and Champion into I/II/III
+# sub-tiers, growing the ladder from 18 ranks to 22. Track entries with a
+# lastUpdated timestamp before this cutoff were stored under the old ladder;
+# entries at or after use the new ladder. Keep this value in sync with the
+# copy in lib/managers/social_manager.py.
+_RANK_EXPANSION_UTC = datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _is_pre_rank_expansion(last_updated: str) -> bool:
+    """Return True if the given ISO8601 lastUpdated timestamp is strictly
+    before the 2026-04-16 rank expansion cutoff. Empty or unparseable strings
+    return False so the caller defaults to the current mapping."""
+    if not last_updated:
+        return False
+    try:
+        ts = datetime.fromisoformat(last_updated.replace('Z', '+00:00'))
+    except (ValueError, TypeError):
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts < _RANK_EXPANSION_UTC
 
 
 class SocialDialog(AccessibleDialog):
@@ -138,11 +163,48 @@ class SocialDialog(AccessibleDialog):
 
         return panel
 
-    def _division_to_rank_name(self, division: int) -> str:
+    def _division_to_rank_name(self, division: int, last_updated: Optional[str] = None) -> str:
         """
-        Convert division number to human-readable rank name
-        In Fortnite: I is lowest, II is middle, III is highest within each tier
+        Convert division number to human-readable rank name.
+        In Fortnite: I is lowest, II is middle, III is highest within each tier.
+
+        If last_updated is supplied and predates the 2026-04-16 rank expansion,
+        the legacy (pre-expansion) mapping is used so stored pre-patch ranks
+        still display correctly. Omitting last_updated uses the current mapping.
         """
+        if last_updated and _is_pre_rank_expansion(last_updated):
+            return self._division_to_rank_name_legacy(division)
+        if division == 0:
+            return "Unranked"
+        elif 1 <= division <= 3:
+            tier = ["I", "II", "III"][division - 1]
+            return f"Bronze {tier}"
+        elif 4 <= division <= 6:
+            tier = ["I", "II", "III"][division - 4]
+            return f"Silver {tier}"
+        elif 7 <= division <= 9:
+            tier = ["I", "II", "III"][division - 7]
+            return f"Gold {tier}"
+        elif 10 <= division <= 12:
+            tier = ["I", "II", "III"][division - 10]
+            return f"Platinum {tier}"
+        elif 13 <= division <= 15:
+            tier = ["I", "II", "III"][division - 13]
+            return f"Diamond {tier}"
+        elif 16 <= division <= 18:
+            tier = ["I", "II", "III"][division - 16]
+            return f"Elite {tier}"
+        elif 19 <= division <= 21:
+            tier = ["I", "II", "III"][division - 19]
+            return f"Champion {tier}"
+        elif division == 22:
+            return "Unreal"
+        else:
+            return f"Division {division}"
+
+    def _division_to_rank_name_legacy(self, division: int) -> str:
+        """Pre-2026-04-16 rank mapping. Elite, Champion, and Unreal each had a
+        single tier and the Unreal cap was at division 18."""
         if division == 0:
             return "Unranked"
         elif 1 <= division <= 3:
@@ -313,15 +375,18 @@ class SocialDialog(AccessibleDialog):
 
                         # API uses 0-indexed divisions for ranked tiers
                         # Division 1 = Bronze II, Division 2 = Bronze III, etc.
-                        # Add 1 to get the display rank
-                        current_rank = self._division_to_rank_name(current_div + 1)
-                        highest_rank = self._division_to_rank_name(highest_div + 1)
+                        # Add 1 to get the display rank.
+                        # lastUpdated lets the mapping fall back to the pre-
+                        # 2026-04-16 ladder for stale pre-expansion records.
+                        last_updated = mode_data.get('lastUpdated')
+                        current_rank = self._division_to_rank_name(current_div + 1, last_updated)
+                        highest_rank = self._division_to_rank_name(highest_div + 1, last_updated)
 
                         # Format: "Battle Royale: Bronze II (20% to Bronze III)"
                         if current_div > 0:
                             # Show next rank
                             next_div = current_div + 2  # +1 for offset, +1 for next tier
-                            next_rank = self._division_to_rank_name(next_div)
+                            next_rank = self._division_to_rank_name(next_div, last_updated)
                             progress_pct = int(progress * 100)
                             ranked_lines.append(f"{mode_name}: {current_rank} ({progress_pct}% to {next_rank})")
                         else:

--- a/lib/managers/social_manager.py
+++ b/lib/managers/social_manager.py
@@ -8,7 +8,7 @@ import time
 import logging
 import threading
 from typing import Optional, List, Dict
-from datetime import datetime
+from datetime import datetime, timezone
 from accessible_output2.outputs.auto import Auto
 
 from lib.config.config_manager import config_manager
@@ -18,6 +18,31 @@ from lib.utilities.epic_social import (
 
 logger = logging.getLogger(__name__)
 speaker = Auto()
+
+
+# Fortnite's 2026-04-16 rank expansion split Elite and Champion into I/II/III
+# sub-tiers, growing the ladder from 18 ranks to 22. Track entries with a
+# lastUpdated timestamp before this cutoff were stored under the old ladder
+# (Elite=16, Champion=17, Unreal=18); entries at or after use the new ladder
+# (Elite I/II/III=16-18, Champion I/II/III=19-21, Unreal=22). The cutoff is
+# intentionally set a little before the patch's actual release so any pre-patch
+# data is correctly detected as pre-expansion.
+_RANK_EXPANSION_UTC = datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _is_pre_rank_expansion(last_updated: str) -> bool:
+    """Return True if the given ISO8601 lastUpdated timestamp is strictly
+    before the 2026-04-16 rank expansion cutoff. Empty or unparseable strings
+    return False so the caller defaults to the current mapping."""
+    if not last_updated:
+        return False
+    try:
+        ts = datetime.fromisoformat(last_updated.replace('Z', '+00:00'))
+    except (ValueError, TypeError):
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts < _RANK_EXPANSION_UTC
 
 
 class SocialManager:
@@ -328,11 +353,48 @@ class SocialManager:
         except Exception as e:
             logger.error(f"Error refreshing slow data: {e}")
 
-    def _division_to_rank_name(self, division: int) -> str:
+    def _division_to_rank_name(self, division: int, last_updated: Optional[str] = None) -> str:
         """
-        Convert division number to human-readable rank name
-        In Fortnite: I is lowest, II is middle, III is highest within each tier
+        Convert division number to human-readable rank name.
+        In Fortnite: I is lowest, II is middle, III is highest within each tier.
+
+        If last_updated is supplied and predates the 2026-04-16 rank expansion,
+        the legacy (pre-expansion) mapping is used so stored pre-patch ranks
+        still display correctly. Omitting last_updated uses the current mapping.
         """
+        if last_updated and _is_pre_rank_expansion(last_updated):
+            return self._division_to_rank_name_legacy(division)
+        if division == 0:
+            return "Unranked"
+        elif 1 <= division <= 3:
+            tier = ["I", "II", "III"][division - 1]
+            return f"Bronze {tier}"
+        elif 4 <= division <= 6:
+            tier = ["I", "II", "III"][division - 4]
+            return f"Silver {tier}"
+        elif 7 <= division <= 9:
+            tier = ["I", "II", "III"][division - 7]
+            return f"Gold {tier}"
+        elif 10 <= division <= 12:
+            tier = ["I", "II", "III"][division - 10]
+            return f"Platinum {tier}"
+        elif 13 <= division <= 15:
+            tier = ["I", "II", "III"][division - 13]
+            return f"Diamond {tier}"
+        elif 16 <= division <= 18:
+            tier = ["I", "II", "III"][division - 16]
+            return f"Elite {tier}"
+        elif 19 <= division <= 21:
+            tier = ["I", "II", "III"][division - 19]
+            return f"Champion {tier}"
+        elif division == 22:
+            return "Unreal"
+        else:
+            return f"Division {division}"
+
+    def _division_to_rank_name_legacy(self, division: int) -> str:
+        """Pre-2026-04-16 rank mapping. Elite, Champion, and Unreal each had a
+        single tier and the Unreal cap was at division 18."""
         if division == 0:
             return "Unranked"
         elif 1 <= division <= 3:
@@ -402,13 +464,16 @@ class SocialManager:
                         mode_name = self._get_ranked_mode_name(ranking_type)
                         # API uses 0-indexed divisions for ranked tiers
                         # Division 1 = Bronze II, Division 2 = Bronze III, etc.
-                        # Add 1 to get the display rank
-                        current_rank = self._division_to_rank_name(current_div + 1)
+                        # Add 1 to get the display rank.
+                        # lastUpdated lets the mapping fall back to the pre-
+                        # 2026-04-16 ladder for stale pre-expansion records.
+                        last_updated = current_data.get('lastUpdated')
+                        current_rank = self._division_to_rank_name(current_div + 1, last_updated)
 
                         if current_div > prev_div:
                             # Promotion!
                             next_div = current_div + 2  # +1 for offset, +1 for next tier
-                            next_rank = self._division_to_rank_name(next_div)
+                            next_rank = self._division_to_rank_name(next_div, last_updated)
                             progress_pct = int(current_progress * 100)
 
                             announcement = f"{mode_name} ranked: Promoted to {current_rank} ({progress_pct}% towards {next_rank})!"
@@ -425,9 +490,10 @@ class SocialManager:
                         # Only announce if progress has changed
                         if current_progress != prev_progress:
                             mode_name = self._get_ranked_mode_name(ranking_type)
-                            current_rank = self._division_to_rank_name(current_div + 1)
+                            last_updated = current_data.get('lastUpdated')
+                            current_rank = self._division_to_rank_name(current_div + 1, last_updated)
                             next_div = current_div + 2  # +1 for offset, +1 for next tier
-                            next_rank = self._division_to_rank_name(next_div)
+                            next_rank = self._division_to_rank_name(next_div, last_updated)
 
                             # Calculate the difference in percentage
                             prev_pct = int(prev_progress * 100)


### PR DESCRIPTION
## Summary

Today's in-game rank update grew the ranked ladder from **18 → 22 divisions**:

- **Elite** expanded from a single tier to three: Elite I / II / III
- **Champion** expanded from a single tier to three: Champion I / II / III
- **Unreal** moved from division 18 to division 22

Confirmed in-game: a Reload Zero Build client showed "Elite II" while the API returned `currentDivision=16` — under the old mapping that would have displayed as "Champion".

## Why a "pre-patch" fallback is needed

Epic's stored `trackprogress` records aren't all migrated the moment the patch drops. A player who was at pre-patch **Unreal** (div 17) but hasn't played ranked since will still have their old snapshot: `currentDivision=17, lastUpdated < patch time`. Under the new mapping alone that would display as "Elite III" instead of their actual "Unreal".

Verified against a known pro (Zemie) whose Reload Zero Build track was last updated `2026-04-08T18:46:44Z` with `currentDivision=17` — pre-patch Unreal.

## What changed

- `_division_to_rank_name` now takes an optional `last_updated` parameter. When the timestamp is before the 2026-04-16 cutoff, it delegates to a new `_division_to_rank_name_legacy` with the old 18-rank mapping. Post-cutoff (or omitted) timestamps use the new 22-rank mapping.
- A small `_is_pre_rank_expansion(last_updated)` helper handles the ISO-8601 parsing (including trailing-Z UTC) and degrades safely to `False` on empty / unparseable input.
- Call sites in `_check_ranked_progress` and the ranked-stats block in `SocialDialog.load_account_info` now pass the track's `lastUpdated` through, so current-rank, highest-rank, and next-rank labels are all resolved under the same mapping.
- The cutoff constant and helper are duplicated across `social_manager.py` and `social_gui.py` to match the existing pattern (both files already carry their own copies of `_division_to_rank_name` / `_get_ranked_mode_name`).

## Test plan

- [x] Unit-style check: synthetic timestamps confirm pre-patch strings (e.g. `2026-04-08T...`) dispatch to legacy, post-patch (`2026-04-16T20:00:00Z`) and empty strings dispatch to new.
- [x] Division table spot-check: 16/17/18 → Elite I/II/III (new) vs Elite/Champion/Unreal (legacy); 22 → Unreal (new only).
- [x] Division 0 still returns "Unranked"; out-of-range still falls through to `Division N`.
- [ ] Run the app against a fresh post-patch session to confirm the labels show up in UI and voice announcements.
- [ ] Re-verify once a pro has played post-patch and pushed past the old Unreal cap (then their `highestDivision` should enter the 19-22 range, proving the top of the new ladder is reachable).

## Notes / follow-ups

- The cutoff is set to `2026-04-16T10:00:00Z` (≈5 AM Central, a little before the patch actually went live) so any lingering pre-patch data is correctly detected as pre-expansion. Adjust if the exact patch time is confirmed differently.
- The existing `next_div = current_div + 2` logic can exceed the top of either ladder (pre-patch it would hit `Division 19`; post-patch it would hit `Division 23`) — unchanged here since this PR is scoped to the expansion mapping itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)