### PR TITLE
Add MatchEventMonitor: real-time match + party event announcements

### DIFF
--- a/FA11y.py
+++ b/FA11y.py
@@ -85,6 +85,7 @@ from lib.monitors.resource_monitor import resource_monitor
 # from lib.monitors.dynamic_object_monitor import dynamic_object_monitor
 from lib.monitors.storm_monitor import storm_monitor
 from lib.monitors.bloom_monitor import bloom_monitor
+from lib.monitors.match_event_monitor import match_event_monitor
 
 from lib.managers.game_object_manager import game_object_manager
 from lib.utilities.window_utils import get_active_window_title, focus_window
@@ -225,6 +226,7 @@ def signal_handler(signum, frame):
         # dynamic_object_monitor.stop_monitoring()
         storm_monitor.stop_monitoring()
         bloom_monitor.stop_monitoring()
+        match_event_monitor.stop_monitoring()
         match_tracker.stop_monitoring()
 
         # Stop social manager
@@ -2326,6 +2328,7 @@ def main() -> None:
         # dynamic_object_monitor.start_monitoring()
         storm_monitor.start_monitoring()
         bloom_monitor.start_monitoring()
+        match_event_monitor.start_monitoring()
 
         # Start new game object system
         match_tracker.start_monitoring()
@@ -2390,6 +2393,13 @@ def main() -> None:
 
                 social_manager = get_social_manager(epic_auth)
                 social_manager.start_monitoring()
+
+                # Wire MatchEventMonitor's party-id resolver to the social
+                # manager's cache so it can turn partial Fortnite-log ids
+                # (e.g. "e7571...92503") into display names. Also pass the
+                # local account id so the monitor can suppress self-adds.
+                match_event_monitor.name_resolver = social_manager.resolve_name_from_partial_id
+                match_event_monitor.local_account_id = epic_auth.account_id
 
                 # Initialize discovery API
                 discovery_api = EpicDiscovery(epic_auth)
@@ -2484,6 +2494,7 @@ def main() -> None:
             resource_monitor.stop_monitoring()
             # dynamic_object_monitor.stop_monitoring()
             storm_monitor.stop_monitoring()
+            match_event_monitor.stop_monitoring()
             match_tracker.stop_monitoring()
 
             # Stop social manager

--- a/lib/managers/social_manager.py
+++ b/lib/managers/social_manager.py
@@ -107,6 +107,50 @@ class SocialManager:
         # Example: fd598199500c4044a0c4f66083349548
         return bool(re.match(r'^[a-f0-9]{32}$', text.lower()))
 
+    def resolve_name_from_partial_id(self, id_or_partial: str) -> Optional[str]:
+        """
+        Resolve an MCP id — full 32-char or an abbreviated
+        '<prefix>...<suffix>' form that Fortnite writes in party-event log
+        lines — to a display name by matching against cached friends and
+        party members. Returns None when no match is found so the caller
+        can fall back to speaking the id.
+
+        Called by MatchEventMonitor via the name_resolver callback wired
+        up in FA11y.main(); safe to call from any thread (read-only scan
+        of caches under the social manager lock).
+        """
+        if not id_or_partial:
+            return None
+
+        # Split once if it's the abbreviated form. Full 32-char hex ids
+        # don't contain '...', so this is a clean discriminator.
+        if '...' in id_or_partial:
+            parts = id_or_partial.split('...', 1)
+            if len(parts) != 2 or not parts[0] or not parts[1]:
+                return None
+            prefix, suffix = parts
+            match_fn = lambda aid: aid.startswith(prefix) and aid.endswith(suffix)
+        else:
+            match_fn = lambda aid: aid == id_or_partial
+
+        with self.lock:
+            for f in self.all_friends:
+                if match_fn(f.account_id):
+                    return self._ensure_display_name(f.display_name)
+            for m in self.party_members:
+                if match_fn(m.account_id):
+                    return self._ensure_display_name(m.display_name)
+            for r in self.incoming_requests:
+                if match_fn(r.account_id):
+                    return self._ensure_display_name(r.display_name)
+            for r in self.outgoing_requests:
+                if match_fn(r.account_id):
+                    return self._ensure_display_name(r.display_name)
+            for inv in self.party_invites:
+                if match_fn(inv.from_account_id):
+                    return self._ensure_display_name(inv.from_display_name)
+        return None
+
     def _ensure_display_name(self, display_name: str) -> str:
         """
         Ensure we have a real display name, not an account ID.
@@ -495,6 +539,12 @@ class SocialManager:
             self.prev_outgoing_count = current_outgoing_count
 
             # Check for new party invites
+            # NOTE: Announcements for invites are now handled by
+            # MatchEventMonitor, which parses `OnPartyInviteReceived` and
+            # `OnPingReceived` from the Fortnite log with sub-second
+            # latency. We keep the API-polled count-change logic here only
+            # to drive auto-accept for invites that came in response to
+            # join requests we sent.
             current_invite_count = len(self.party_invites)
             if current_invite_count > self.prev_party_invite_count:
                 new_count = current_invite_count - self.prev_party_invite_count
@@ -511,7 +561,7 @@ class SocialManager:
                             # Check if we can auto-accept (Fortnite must be focused)
                             from lib.utilities.window_utils import get_active_window_title
                             active_title = get_active_window_title()
-                            
+
                             if active_title and "Fortnite" in active_title:
                                 # Auto-accept! They accepted our join request
                                 logger.debug(f"Auto-accepting invite from {display_name} (responded to our join request)")
@@ -523,58 +573,26 @@ class SocialManager:
                                     args=(latest_invite, display_name),
                                     daemon=True
                                 ).start()
-                            else:
-                                # Fortnite not focused, treat as normal invite
-                                logger.debug(f"Cannot auto-accept invite from {display_name}: Fortnite not focused")
-                                self._show_notification(latest_invite, "party_invite")
-                        else:
-                            # Expired, show normal notification
-                            self._show_notification(latest_invite, "party_invite")
-                    else:
-                        # Normal invite, show notification
-                        self._show_notification(latest_invite, "party_invite")
-                elif new_count > 1:
-                    speaker.speak(f"{new_count} new party invites. Open social menu to review.")
-            
+                            # Else: MatchEventMonitor already announced the
+                            # invite; nothing extra to do here.
+
             self.prev_party_invite_count = current_invite_count
 
-        # Check for party changes (joins/leaves)
-        # We need to get the current party members to compare
-        # This assumes refresh_slow_data or similar updates self.party_members periodically
-        # or we rely on the fact that we just refreshed data if we are here?
-        # Actually, _monitor_loop calls refresh_slow_data which updates self.party_members.
-        # We need to store the *previous* state to compare.
-        
-        # Initialize prev_party_members if not exists
+        # NOTE: Party member joined/left announcements are now driven by
+        # MatchEventMonitor parsing `LogParty: Verbose: Adding [<name>]`
+        # and `HandleZonePlayerStateRemoved: [MCP:<id>]` from the Fortnite
+        # log. Those fire instantly (vs. the 30s slow-poll cadence here)
+        # and carry display names inline. The old diff-based announcements
+        # here were removed to avoid duplicate speech.
+        # The previous-id set itself is still tracked because other code
+        # paths may rely on it.
         if not hasattr(self, 'prev_party_members_ids'):
             self.prev_party_members_ids = set()
             if self.party_members:
                 self.prev_party_members_ids = {m.account_id for m in self.party_members}
-        
-        current_member_ids = {m.account_id for m in self.party_members} if self.party_members else set()
-        
-        # Calculate diffs
-        joined_ids = current_member_ids - self.prev_party_members_ids
-        left_ids = self.prev_party_members_ids - current_member_ids
-        
-        # Announce joins
-        for member_id in joined_ids:
-            # Find member object for name
-            member = next((m for m in self.party_members if m.account_id == member_id), None)
-            name = member.display_name if member else "Player"
-            # Don't announce our own join if we just started
-            if member_id != self.social_api.auth.account_id: 
-                 speaker.speak(f"{name} joined the party")
-        
-        # Announce leaves
-        for member_id in left_ids:
-            # We can't look up name in current members, need to rely on cache or generic
-            # Ideally we'd have kept the old member objects, but for now:
-            name = self.social_api._get_display_name(member_id) # This uses cache
-            if member_id != self.social_api.auth.account_id:
-                speaker.speak(f"{name} left the party")
-                
-        self.prev_party_members_ids = current_member_ids
+        self.prev_party_members_ids = {
+            m.account_id for m in self.party_members
+        } if self.party_members else set()
 
     def _show_notification(self, item, item_type):
         """

--- a/lib/monitors/match_event_monitor.py
+++ b/lib/monitors/match_event_monitor.py
@@ -1,0 +1,587 @@
+"""
+Real-time match event monitor for FA11y.
+
+Tails Fortnite's local log file (FortniteGame.log) and announces in-game
+events through the screen reader. This is the only practical way to surface
+information that Epic doesn't expose via any public API:
+
+  - Reload knocked / can-respawn / respawning / respawned state changes
+  - Players-remaining count (parsed from EOS rich-presence updates)
+  - Match phases (bus locked, bus flying, storm forming/holding/shrinking)
+  - Death / final placement / spectating
+  - Final-countdown player count (Reload/box-fights endgame)
+
+Every announcement is gated by a separate config toggle so users can keep
+only what they want.
+
+Implementation notes:
+  - The log file gets renamed to FortniteGame-backup-<timestamp>.log when
+    Fortnite launches a fresh instance. We re-open by inode (st_ino on
+    POSIX, st_ino is also returned on Windows by os.stat) and by mtime as
+    a fallback.
+  - We pick up where Fortnite's writer is, not the start of the file. On
+    initial start we seek to the end so historical events don't all replay.
+"""
+
+import os
+import re
+import threading
+import time
+import logging
+from typing import Optional
+
+from accessible_output2.outputs.auto import Auto
+
+from lib.utilities.utilities import read_config, get_config_boolean, on_config_change
+
+logger = logging.getLogger(__name__)
+
+
+# Default location for Fortnite's log directory on Windows. Other platforms
+# can't run Fortnite, so this is the only path we need to try.
+_DEFAULT_LOG_DIR = os.path.join(
+    os.environ.get('LOCALAPPDATA', ''),
+    'FortniteGame', 'Saved', 'Logs'
+)
+_LOG_FILENAME = 'FortniteGame.log'
+
+
+# --- Event patterns -----------------------------------------------------
+#
+# Each pattern targets exactly one log signature we verified against a real
+# match log. Patterns are anchored loosely (no leading timestamp matching)
+# so future log format tweaks don't silently break detection.
+
+# Reload "instant reboot" widget (the on-screen prompt that says you can
+# hold reload to instantly respawn while DBNO).
+_RE_DBNO_KNOCKED = re.compile(
+    r'BlastBerryInstantRebootWidget.*widget is now active.*Invincibility tag has been removed and player is DBNO'
+)
+_RE_RESPAWN_HELD = re.compile(
+    r'BlastBerryInstantRebootWidget.*HandleInputPressed Action name is: Reload'
+)
+_RE_RESPAWN_RECOVERED = re.compile(
+    r'BlastBerryInstantRebootWidget.*widget is now inactive.*Player is not DBNO anymore'
+)
+_RE_RESPAWN_DISABLED = re.compile(
+    r'BlastBerryInstantRebootWidget.*widget is now inactive.*respawn has been disabled'
+)
+
+# EOS rich-presence text. The game updates this every time the player
+# count changes, with the form "<Mode> - <N> Left".
+_RE_PRESENCE = re.compile(
+    r'LogEOSPresence: Updating Presence.*RichText=\[(?P<text>[^\]]*)\]'
+)
+_RE_PRESENCE_PLAYERS = re.compile(r'(?P<mode>.+?)\s*-\s*(?P<count>\d+)\s*Left', re.IGNORECASE)
+
+# Battle royale game-phase logic. Two flavours: HandleGamePhaseChanged
+# (top-level phase: Setup/Warmup/Aircraft/SafeZones) and UpdateGamePhaseStep
+# (sub-step: BusLocked/BusFlying/StormForming/StormHolding/StormShrinking).
+_RE_PHASE_CHANGED = re.compile(
+    r'LogBattleRoyaleGamePhaseLogic: HandleGamePhaseChanged.*NewPhase = EAthenaGamePhase::(?P<phase>\w+)'
+)
+_RE_PHASE_STEP = re.compile(
+    r'LogBattleRoyaleGamePhaseLogic: UpdateGamePhaseStep\..*PhaseStep = EAthenaGamePhaseStep::(?P<step>\w+)'
+)
+
+# You died (cursor opens the death/spectate menu).
+_RE_DEATH = re.compile(r'LogFortHUDContext.*Entering cursor mode \(Show Death Spectator Menu\)')
+
+# View-target changes. After death the player cycles through spectator
+# subjects with the next-player button, which emits "from Pawn:<a> to
+# Pawn:<b>" for each switch. The first change after death is from a
+# FortSpectator pawn (the helper camera the game inserts), subsequent
+# ones are player-to-player. We accept both and use a state flag to
+# only announce while we're actually in spectator mode.
+_RE_VIEW_TARGET = re.compile(
+    r'LogFortViewTarget.*trying to set view target from\s+(?P<src>\S+)\s+to\s+Pawn:(?P<name>\S+(?:\[\d+\])?)'
+)
+
+# Match-end placement determined.
+_RE_PLACEMENT = re.compile(r'LocalPlacementChanged We now have placement for the local player')
+
+# Reload/box-fights final countdown player count warnings.
+_RE_FINAL_COUNTDOWN = re.compile(
+    r'FortAthenaMutator_FinalCountdown.*WarnCountdownStartingSoon.*PlayersRemaining:\s*(?P<count>\d+)'
+)
+
+# --- Party events ---
+#
+# These events are fired by Fortnite when party state changes. Parsing them
+# from the log gives us sub-second latency and removes the need to poll the
+# social API for invites or membership changes. They deliberately do NOT have
+# their own config toggles — the API-polled versions they replace were also
+# always-on.
+#
+# OnPartyInviteReceived: someone invited you to their party.
+_RE_PARTY_INVITE_RECEIVED = re.compile(
+    r'LogOnlineParty:\s*MCP:\s*OnPartyInviteReceived:.*?Sender=\[(?P<sender>[^\]]+)\]'
+)
+# OnPingReceived: someone pinged you asking to join your party.
+_RE_PARTY_PING_RECEIVED = re.compile(
+    r'LogOnlineParty:\s*MCP:\s*OnPingReceived:.*?Sender=\[(?P<sender>[^\]]+)\]'
+)
+# JoinParty (local request kicked off) — carries the other party's display
+# name inline, which is a rare luxury in these logs.
+_RE_PARTY_JOIN_ATTEMPT = re.compile(
+    r'LogOnlineParty:\s*MCP:\s*JoinParty:.*?SourceDisplayName\((?P<name>[^)]+)\)'
+)
+# LogParty: Verbose: Adding [<name>] Id [MCP:<id>] ... — fires when a member
+# (you or someone else) is inserted into the party's in-game team. The line
+# contains the display name verbatim, so no partial-ID resolver is needed.
+# Only emitted at Verbose log level, which is Fortnite's default for this
+# category on all profiles we've checked.
+_RE_PARTY_MEMBER_ADDED = re.compile(
+    r'LogParty:\s*Verbose:\s*Adding\s*\[(?P<name>[^\]]+)\]\s*Id\s*\[MCP:(?P<id>[^\]]+)\]\s*as a new member'
+)
+# HandleZonePlayerStateRemoved: member left. No name in the line, so we rely
+# on the _party_member_names cache populated by prior Added events.
+_RE_PARTY_MEMBER_REMOVED = re.compile(
+    r'LogParty:.*?HandleZonePlayerStateRemoved:\s*\[MCP:(?P<id>[^\]]+)\]'
+)
+
+
+# Phase-step strings worth announcing. Filtered to high-signal events;
+# 'None' steps and intermediate transitions are noise.
+_INTERESTING_STEPS = {
+    'BusLocked': 'Battle bus locked',
+    'BusFlying': 'Battle bus flying',
+    'StormForming': 'Storm forming',
+    'StormHolding': 'Storm holding',
+    'StormShrinking': 'Storm shrinking',
+    'GetReady': 'Get ready',
+}
+
+
+class MatchEventMonitor:
+    """Tails the Fortnite log file in a background thread and speaks events."""
+
+    def __init__(self):
+        self.speaker = Auto()
+        self.running = False
+        self.thread = None
+        self._stop_event = threading.Event()
+
+        # File-tracking state.
+        self._log_path = os.path.join(_DEFAULT_LOG_DIR, _LOG_FILENAME)
+        self._fp = None
+        self._inode = None
+
+        # Per-event de-duplication state. The log can repeat some lines
+        # (e.g. multiple "trying to set view target" while loading) so we
+        # remember the last value and only speak on real changes.
+        self._last_player_count = None
+        self._last_mode = None
+        self._last_phase = None
+        self._last_step = None
+        self._last_spectate_target = None
+        self._last_final_countdown = None
+
+        # Spectator mode flag. Set on death, cleared on respawn or match
+        # end. We need this because view-target changes happen during
+        # normal play too (entering vehicles, getting downed, etc.) — only
+        # changes that happen while we're spectating should be announced.
+        self._spectating = False
+
+        # Party-event state. _party_member_names maps MCP id -> display
+        # name so we can announce "X left the party" when we only get an
+        # id in the removal line. Populated by LogParty: Verbose: Adding
+        # events. Cleared when the local user leaves the party.
+        self._party_member_names: dict = {}
+
+        # Resolver callback for "Sender=[<short>...<short>]" partial ids
+        # in OnPartyInviteReceived / OnPingReceived. Set by FA11y at
+        # startup once SocialManager is available. Signature:
+        #   callable(partial_id: str) -> Optional[str]
+        # Left as None means "announce with the partial id as-is".
+        self.name_resolver = None
+
+        # Local account id, set by FA11y at startup. Used to suppress
+        # "joined the party" announcements for yourself when the Adding
+        # event fires for the local user.
+        self.local_account_id: Optional[str] = None
+
+        # Config flags.
+        self.config = read_config()
+        self._reload_config_flags()
+        on_config_change(self._on_config_change)
+
+    # -- config -----------------------------------------------------------
+
+    def _reload_config_flags(self):
+        c = self.config
+        self.enabled = get_config_boolean(c, 'MonitorMatchEvents', True)
+        self.announce_dbno = get_config_boolean(c, 'AnnounceReloadKnocked', True)
+        self.announce_respawn = get_config_boolean(c, 'AnnounceReloadRespawn', True)
+        self.announce_players_left = get_config_boolean(c, 'AnnouncePlayersLeft', True)
+        self.announce_phase = get_config_boolean(c, 'AnnounceMatchPhase', True)
+        self.announce_death = get_config_boolean(c, 'AnnounceDeath', True)
+        self.announce_spectate = get_config_boolean(c, 'AnnounceSpectating', True)
+        self.announce_placement = get_config_boolean(c, 'AnnouncePlacement', True)
+        self.announce_final_countdown = get_config_boolean(c, 'AnnounceFinalCountdown', True)
+
+    def _on_config_change(self, config):
+        self.config = config
+        self._reload_config_flags()
+
+    # -- file handling ----------------------------------------------------
+
+    def _open_log(self) -> bool:
+        """Open the log file and seek to the end. Returns True on success."""
+        try:
+            if not os.path.exists(self._log_path):
+                return False
+            # Use binary mode + manual decode so a partial UTF-8 sequence at
+            # the tail (writer mid-write) doesn't raise.
+            self._fp = open(self._log_path, 'rb')
+            self._fp.seek(0, os.SEEK_END)
+            self._inode = os.stat(self._log_path).st_ino
+            end_pos = self._fp.tell()
+            logger.info(
+                f"MatchEventMonitor: tailing {self._log_path} "
+                f"(starting at byte {end_pos}, inode {self._inode})"
+            )
+            return True
+        except Exception as e:
+            logger.info(f"MatchEventMonitor: could not open log: {e}")
+            self._fp = None
+            return False
+
+    def _check_rotation(self):
+        """If the file was rotated (Fortnite restarted), re-open it."""
+        try:
+            stat = os.stat(self._log_path)
+        except OSError:
+            # File temporarily missing during rotation; try again next tick.
+            return
+        if stat.st_ino != self._inode:
+            logger.info(
+                f"MatchEventMonitor: log rotation detected "
+                f"(old inode {self._inode} -> new inode {stat.st_ino}), re-opening"
+            )
+            try:
+                if self._fp:
+                    self._fp.close()
+            except Exception:
+                pass
+            # New log is a fresh game session - reset per-match dedupe state
+            # so we don't suppress legitimate first-event announcements.
+            self._last_player_count = None
+            self._last_mode = None
+            self._last_phase = None
+            self._last_step = None
+            self._last_spectate_target = None
+            self._last_final_countdown = None
+            self._spectating = False
+            # Party cache is per-Fortnite-session: new game means Fortnite
+            # will re-emit Adding events for any existing party members.
+            self._party_member_names.clear()
+            self._open_log()
+
+    def _read_new_lines(self):
+        """Yield any new full lines appended since the last read."""
+        if self._fp is None:
+            return
+        try:
+            chunk = self._fp.read()
+        except Exception as e:
+            logger.debug(f"MatchEventMonitor: read error: {e}")
+            return
+        if not chunk:
+            return
+        # Buffer-and-split so we never emit a partial line.
+        buf = getattr(self, '_pending', b'') + chunk
+        lines = buf.split(b'\n')
+        self._pending = lines[-1]  # keep partial last line for next iteration
+        for raw in lines[:-1]:
+            try:
+                yield raw.decode('utf-8', errors='replace')
+            except Exception:
+                continue
+
+    # -- event handling ---------------------------------------------------
+
+    def _speak(self, text: str):
+        # Log every announcement at INFO so we can correlate "user heard
+        # nothing" with "monitor thought it announced" in the FA11y log.
+        logger.info(f"MatchEventMonitor: announcing {text!r}")
+        try:
+            self.speaker.speak(text)
+        except Exception as e:
+            # Screen reader may transiently fail (COM errors with SAPI);
+            # don't let it kill the monitor thread.
+            logger.info(f"MatchEventMonitor: speak failed: {e}")
+
+    def _process_line(self, line: str):
+        # --- Reload DBNO / respawn (user-requested core feature) ---
+        if _RE_DBNO_KNOCKED.search(line):
+            if self.announce_dbno:
+                self._speak("Knocked. Hold reload to respawn.")
+            return
+        if _RE_RESPAWN_HELD.search(line):
+            if self.announce_respawn:
+                self._speak("Respawning")
+            return
+        if _RE_RESPAWN_RECOVERED.search(line):
+            # Got back up - we're alive again, exit spectator mode if set.
+            self._spectating = False
+            self._last_spectate_target = None
+            if self.announce_respawn:
+                self._speak("Respawned")
+            return
+        if _RE_RESPAWN_DISABLED.search(line):
+            if self.announce_respawn:
+                self._speak("Respawn unavailable")
+            return
+
+        # --- Players left (rich presence) ---
+        m = _RE_PRESENCE.search(line)
+        if m:
+            text = m.group('text').strip()
+            pm = _RE_PRESENCE_PLAYERS.search(text)
+            if pm:
+                count = int(pm.group('count'))
+                mode = pm.group('mode').strip()
+                if self.announce_players_left and count != self._last_player_count:
+                    # First appearance per-mode is the match-start lobby
+                    # population; quieter wording for that case.
+                    if self._last_player_count is None or self._last_mode != mode:
+                        self._speak(f"{count} players in match")
+                    else:
+                        self._speak(f"{count} left")
+                    self._last_player_count = count
+                    self._last_mode = mode
+            else:
+                # Empty/lobby presence - reset so next match starts fresh.
+                if self._last_player_count is not None:
+                    self._last_player_count = None
+                    self._last_mode = None
+            return
+
+        # --- Match phase ---
+        m = _RE_PHASE_CHANGED.search(line)
+        if m:
+            phase = m.group('phase')
+            if phase != self._last_phase:
+                self._last_phase = phase
+                # A new Warmup means a new match has started - exit any
+                # leftover spectator state from the previous round.
+                if phase in ('Setup', 'Warmup'):
+                    self._spectating = False
+                    self._last_spectate_target = None
+                if self.announce_phase:
+                    spoken = {
+                        'Warmup': 'Warmup',
+                        'Aircraft': 'On the battle bus',
+                        'SafeZones': 'Match started',
+                    }.get(phase)
+                    if spoken:
+                        self._speak(spoken)
+            return
+
+        m = _RE_PHASE_STEP.search(line)
+        if m and self.announce_phase:
+            step = m.group('step')
+            if step != self._last_step and step in _INTERESTING_STEPS:
+                self._last_step = step
+                self._speak(_INTERESTING_STEPS[step])
+            return
+
+        # --- Death ---
+        if _RE_DEATH.search(line):
+            # Track spectator mode regardless of whether announce_death is
+            # on, so spectate-target announcements still work when death
+            # itself is muted.
+            self._spectating = True
+            self._last_spectate_target = None
+            if self.announce_death:
+                self._speak("You died")
+            return
+
+        # --- Spectating (only while in spectator mode after death) ---
+        m = _RE_VIEW_TARGET.search(line)
+        if m and self._spectating and self.announce_spectate:
+            src = m.group('src')
+            target = m.group('name')
+            # Skip self-confirmations the game emits after every real
+            # switch (e.g. "from Pawn:Foo to Pawn:Foo").
+            if src == f'Pawn:{target}':
+                return
+            if target != self._last_spectate_target:
+                self._last_spectate_target = target
+                # "Anonymous[282]" -> "Anonymous player" for screen reader.
+                if target.startswith('Anonymous'):
+                    spoken_name = 'Anonymous player'
+                else:
+                    spoken_name = target
+                self._speak(f"Spectating {spoken_name}")
+            return
+
+        # --- Final placement ---
+        if _RE_PLACEMENT.search(line):
+            # Match ended - exit spectator mode.
+            self._spectating = False
+            self._last_spectate_target = None
+            if self.announce_placement:
+                self._speak("Match ended")
+            return
+
+        # --- Final countdown player count ---
+        m = _RE_FINAL_COUNTDOWN.search(line)
+        if m and self.announce_final_countdown:
+            count = int(m.group('count'))
+            if count != self._last_final_countdown:
+                self._last_final_countdown = count
+                self._speak(f"Final countdown: {count} players left")
+            return
+
+        # --- Party invite received (someone invited you to their party) ---
+        m = _RE_PARTY_INVITE_RECEIVED.search(line)
+        if m:
+            sender = m.group('sender')
+            name = self._resolve_party_identity(sender)
+            self._speak(f"Party invite from {name}")
+            return
+
+        # --- Ping received (someone requesting to join your party) ---
+        m = _RE_PARTY_PING_RECEIVED.search(line)
+        if m:
+            sender = m.group('sender')
+            name = self._resolve_party_identity(sender)
+            self._speak(f"{name} is requesting to join your party")
+            return
+
+        # --- You joined someone's party ---
+        m = _RE_PARTY_JOIN_ATTEMPT.search(line)
+        if m:
+            name = m.group('name').strip()
+            if name:
+                self._speak(f"Joined {name}'s party")
+            return
+
+        # --- Party member added (this includes yourself on party create) ---
+        m = _RE_PARTY_MEMBER_ADDED.search(line)
+        if m:
+            name = m.group('name').strip()
+            account_id = m.group('id').strip()
+            # Cache the id -> name mapping so we can report who left later.
+            if account_id and name:
+                self._party_member_names[account_id] = name
+            # Skip the self-add that fires on party creation / join. We
+            # already announced "Joined X's party" in the JoinParty case
+            # for joins, and a create doesn't need an announcement.
+            if self.local_account_id and account_id == self.local_account_id:
+                return
+            if name:
+                self._speak(f"{name} joined the party")
+            return
+
+        # --- Party member removed ---
+        m = _RE_PARTY_MEMBER_REMOVED.search(line)
+        if m:
+            account_id = m.group('id').strip()
+            # If it's us being removed, we left the party — drop the cache
+            # and stay quiet (FA11y's existing self-state logic will
+            # handle that path).
+            if self.local_account_id and account_id == self.local_account_id:
+                self._party_member_names.clear()
+                return
+            # Prefer the cached name from when they joined; fall back to
+            # a partial id so there's still a useful announcement.
+            name = self._party_member_names.pop(account_id, None)
+            if not name:
+                name = self._resolve_party_identity(account_id)
+            self._speak(f"{name} left the party")
+            return
+
+    def _resolve_party_identity(self, partial_or_full_id: str) -> str:
+        """Turn a party-log id (either a partial 'xxxxx...xxxxx' or a full
+        MCP id) into a display name. Falls back to returning the raw id if
+        no resolver is configured or no match is found — better a clumsy
+        announcement than silent."""
+        resolver = self.name_resolver
+        if resolver:
+            try:
+                name = resolver(partial_or_full_id)
+            except Exception as e:
+                logger.info(f"MatchEventMonitor: name_resolver raised: {e}")
+                name = None
+            if name:
+                return name
+        return partial_or_full_id
+
+    # -- main loop --------------------------------------------------------
+
+    def _monitor_loop(self):
+        logger.info(f"MatchEventMonitor: loop entered, waiting for log at {self._log_path}")
+        # Wait for log file to appear (Fortnite may not be running yet).
+        attempts = 0
+        while self.running and not self._open_log():
+            attempts += 1
+            if attempts == 1 or attempts % 12 == 0:
+                # First miss + every minute; avoid spamming the log.
+                logger.info(
+                    f"MatchEventMonitor: log not present yet, retrying "
+                    f"(attempt {attempts}, path={self._log_path})"
+                )
+            if self._stop_event.wait(timeout=5.0):
+                return
+        logger.info("MatchEventMonitor: entering main read loop")
+
+        last_rotation_check = time.monotonic()
+        while self.running:
+            if self._stop_event.wait(timeout=0.25):
+                break
+            if not self.enabled:
+                continue
+            try:
+                # Cheap rotation check every ~2 seconds (stat is fast but
+                # not free, and rotations only happen on game restart).
+                now = time.monotonic()
+                if now - last_rotation_check > 2.0:
+                    self._check_rotation()
+                    last_rotation_check = now
+                if self._fp is None:
+                    if not self._open_log():
+                        continue
+                for line in self._read_new_lines():
+                    self._process_line(line)
+            except Exception as e:
+                logger.debug(f"MatchEventMonitor: loop error: {e}")
+                # Brief backoff so a persistent error doesn't pin a CPU.
+                if self._stop_event.wait(timeout=1.0):
+                    break
+
+        # Cleanup on exit.
+        try:
+            if self._fp:
+                self._fp.close()
+        except Exception:
+            pass
+        self._fp = None
+
+    def start_monitoring(self):
+        if self.running:
+            logger.info("MatchEventMonitor: start_monitoring called but already running")
+            return
+        logger.info(
+            f"MatchEventMonitor: starting thread "
+            f"(enabled={self.enabled}, "
+            f"announce_phase={self.announce_phase}, "
+            f"announce_players_left={self.announce_players_left}, "
+            f"announce_dbno={self.announce_dbno})"
+        )
+        self.running = True
+        self._stop_event.clear()
+        self.thread = threading.Thread(target=self._monitor_loop, daemon=True, name='MatchEventMonitor')
+        self.thread.start()
+
+    def stop_monitoring(self):
+        self.running = False
+        self._stop_event.set()
+        if self.thread:
+            self.thread.join(timeout=1.0)
+
+
+# Single shared instance, matching the pattern of other monitors.
+match_event_monitor = MatchEventMonitor()

--- a/lib/utilities/utilities.py
+++ b/lib/utilities/utilities.py
@@ -346,6 +346,17 @@ Decline Notification = lalt+n "Decline pending notification (friend request, par
 Recapture Mouse = lalt+lshift+m "Recapture the mouse device for passthrough. Use when changing mice."
 Toggle Mouse Passthrough = lalt+lshift+p "Toggles mouse passthrough on or off."
 
+[MatchEvents]
+MonitorMatchEvents = true "Master toggle for the in-match log event monitor. Tails Fortnite's local log file to surface real-time events the screen reader otherwise cannot see."
+AnnounceReloadKnocked = true "Announce when you are knocked down in Reload mode."
+AnnounceReloadRespawn = true "Announce when you start respawning, finish respawning, or respawn becomes unavailable in Reload mode."
+AnnouncePlayersLeft = true "Announce the players-remaining count whenever it changes (parsed from Epic rich presence)."
+AnnounceMatchPhase = true "Announce battle bus, storm forming, storm holding, and storm shrinking phase changes."
+AnnounceDeath = true "Announce when you die."
+AnnounceSpectating = true "Announce when you start spectating a new player after death."
+AnnouncePlacement = true "Announce when the match has ended and your final placement is set."
+AnnounceFinalCountdown = true "Announce the final countdown player count for Reload and Box Fights endgames."
+
 [POI]
 selected_poi = closest, 0, 0
 current_map = main"""


### PR DESCRIPTION
## Summary

Epic's public API doesn't expose anything about what's happening inside an active match, and the party-state polling it does expose has a 5-30s worst-case latency. This PR adds a background thread that tails Fortnite's local `FortniteGame.log`, pattern-matches a curated set of event signatures, and announces them through the screen reader. It also replaces the API-polled party-invite / party-member-joined / party-member-left announcements with log-based versions that are both instant and come with display names inline.

## Events surfaced

### In-match (each gated by a config toggle in new `[MatchEvents]` section)

| Config | Announcement | Log signature |
|---|---|---|
| `AnnounceReloadKnocked` | \"Knocked. Hold reload to respawn.\" | `BlastBerryInstantRebootWidget ... widget is now active ... player is DBNO` |
| `AnnounceReloadRespawn` | \"Respawning\" / \"Respawned\" / \"Respawn unavailable\" | same widget, different reasons |
| `AnnouncePlayersLeft` | \"N left\" / \"N players in match\" | `LogEOSPresence: Updating Presence ... RichText=[<Mode> - N Left]` |
| `AnnounceMatchPhase` | \"Warmup\" / \"On the battle bus\" / \"Battle bus locked\" / \"Battle bus flying\" / \"Get ready\" / \"Storm forming\" / \"Storm holding\" / \"Storm shrinking\" / \"Match started\" | `LogBattleRoyaleGamePhaseLogic: HandleGamePhaseChanged` & `UpdateGamePhaseStep` |
| `AnnounceDeath` | \"You died\" | `LogFortHUDContext ... Entering cursor mode (Show Death Spectator Menu)` |
| `AnnounceSpectating` | \"Spectating <name>\" | `LogFortViewTarget ... trying to set view target` (only while in post-death spectator mode) |
| `AnnouncePlacement` | \"Match ended\" | `LocalPlacementChanged We now have placement for the local player` |
| `AnnounceFinalCountdown` | \"Final countdown: N players left\" | `FortAthenaMutator_FinalCountdown ... WarnCountdownStartingSoon ... PlayersRemaining: N` |

### Party (always on — replaces API-polled versions that were always on)

| Announcement | Log signature |
|---|---|
| \"Party invite from <name>\" | `LogOnlineParty: MCP: OnPartyInviteReceived: ... Sender=[<id>]` |
| \"<name> is requesting to join your party\" | `LogOnlineParty: MCP: OnPingReceived: ... Sender=[<id>]` |
| \"Joined <name>'s party\" | `LogOnlineParty: MCP: JoinParty: ... SourceDisplayName(<name>)` |
| \"<name> joined the party\" | `LogParty: Verbose: Adding [<name>] Id [MCP:<id>] as a new member` |
| \"<name> left the party\" | `LogParty: Display: HandleZonePlayerStateRemoved: [MCP:<id>]` (name from cache populated on Adding) |

### Name resolution

The `OnPartyInviteReceived` and `OnPingReceived` lines include an abbreviated sender id in the form `xxxxx...yyyyy` — 5-char prefix + literal \`...\` + 5-char suffix. `SocialManager.resolve_name_from_partial_id` matches that against cached friends, party members, and pending friend requests / party invites, returning the display name when found. `FA11y.main` wires this as the monitor's `name_resolver` callback right after the social manager is initialized. If no match is found, the announcement falls back to speaking the id verbatim — clumsy but never silent.

\"Adding\" events include the display name inline so no resolver is needed. \"HandleZonePlayerStateRemoved\" has only the full MCP id; we cache the name from the prior Adding event (cleared on log rotation / new Fortnite session). Self-adds (when you create or join a party) are suppressed via the `local_account_id` FA11y also wires at startup.

## API-polled announcements that were removed

In `SocialManager._check_for_new_items`:

- Single new party invite → \`self._show_notification(latest_invite, \"party_invite\")\` (3 call sites, covering auto-accept fallback paths)
- Multiple new party invites batch → \`speaker.speak(f\"{new_count} new party invites. Open social menu to review.\")\`
- Party member joined → \`speaker.speak(f\"{name} joined the party\")\`
- Party member left → \`speaker.speak(f\"{name} left the party\")\`

The count-change detection itself is retained because the auto-accept flow (outgoing join request → incoming invite within 90s → silent accept if Fortnite is focused) depends on it. Nothing a user hears changes about auto-accept.

Friend-request announcements and the \"N new incoming friend requests\" batch are untouched — those flow through a separate API that the log doesn't surface equivalently.

## Diagnostic logging

Every successful `_open_log`, rotation detection, and `_speak` call now emits an `INFO`-level line tagged `MatchEventMonitor:` in the FA11y log, plus startup and first-open-retry markers. This is how we diagnosed a silent monitor earlier — silence in a healthy run is now visible as \"tailing … (starting at byte N, inode X)\" followed by one line per announcement.

## Test plan

- [x] Syntax: all 4 modified/new files parse with `ast.parse`
- [x] Unit: each of the 5 party regexes matches a real log line sampled from yesterday's Reload session
- [x] End-to-end: feeding the real sequence of 7 log lines through `_process_line` produces exactly the 5 expected announcements with correct name resolution, and the self-add on party create is suppressed
- [ ] Live BR / Reload match with log-based monitor running — looking for the new `INFO` diagnostic lines and correct party-event speech
- [ ] Verify auto-accept still fires when a targeted invite arrives within 90s of an outgoing join request and Fortnite is focused

## Files touched

- `lib/monitors/match_event_monitor.py` (new, 587 lines)
- `FA11y.py` (import + start/stop + resolver wiring, 11 lines)
- `lib/managers/social_manager.py` (add resolver, trim API announcements, 112 lines changed)
- `lib/utilities/utilities.py` (add `[MatchEvents]` default config section, 11 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)