### PR TITLE
Add Client Settings editor with Epic cloud sync

### DIFF
--- a/FA11y.py
+++ b/FA11y.py
@@ -444,6 +444,7 @@ def reload_config() -> None:
             'announce reload map rotation': announce_reload_map_rotation,
             'sync current map to reload rotation': sync_current_map_to_reload_rotation,
             'open configuration menu': open_config_gui,
+            'open client settings': open_clientsettings_editor,
             'exit match': exit_match,
             'create custom p o i': handle_custom_poi_gui,
             'announce ammo': announce_ammo_manually,
@@ -1280,6 +1281,18 @@ def update_script_config(new_config: configparser.ConfigParser) -> None:
     except Exception as e:
         print(f"Error updating script config: {e}")
         speaker.speak("Error updating configuration")
+
+def open_clientsettings_editor() -> None:
+    """Open the Client Settings editor (Fortnite sens/binds/volumes + cloud sync)."""
+    try:
+        from lib.guis.clientsettings_gui import launch_clientsettings_editor
+    except Exception as e:
+        print(f"Error loading Client Settings editor: {e}")
+        speaker.speak("Error loading Client Settings editor")
+        return
+    speaker.speak("Opening Client Settings editor")
+    launch_clientsettings_editor()
+
 
 def open_config_gui() -> None:
     """Open the configuration GUI."""

--- a/lib/guis/clientsettings_gui.py
+++ b/lib/guis/clientsettings_gui.py
@@ -1,0 +1,1113 @@
+"""
+Client Settings Editor GUI for FA11y.
+
+Lets the user view and modify values inside Fortnite's ClientSettings.Sav
+(sensitivity, FOV, volumes, keybinds, etc.) and push the result to their
+Epic cloud storage, so settings follow them across devices.
+
+Uses FA11y's existing EpicAuth session — no separate login.
+
+Layout
+------
+Notebook with three tabs:
+    1. "Settings"  — sensitivity (% display), FOV, audio volumes, region, toggles
+    2. "Keybinds"  — per-sub-game binding list; double-click a row to edit
+    3. "Cloud"     — show cloud file info, Push / Pull / Diff actions
+
+Values are edited in-memory on the loaded ClientSettingsFile. Writes happen
+only when the user clicks one of the explicit Save / Push buttons.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+import wx
+from accessible_output2.outputs.auto import Auto
+
+from lib.guis.gui_utilities import (
+    AccessibleDialog,
+    BoxSizerHelper,
+    ButtonHelper,
+    BORDER_FOR_DIALOGS,
+    SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS,
+    launch_gui_thread_safe,
+    messageBox,
+)
+from lib.utilities.clientsettings_parser import (
+    ClientSettingsFile,
+    find_property,
+    get_value,
+    parse_file,
+    serialize_file,
+    set_value,
+)
+from lib.utilities.clientsettings_sync import (
+    CLIENT_SETTINGS_FILENAME,
+    ClientSettingsManager,
+    diff_settings,
+    is_fortnite_running,
+    locate_local,
+)
+
+logger = logging.getLogger(__name__)
+speaker = Auto()
+
+
+# ---------------------------------------------------------------------------
+# Conversions
+# ---------------------------------------------------------------------------
+
+# Fortnite's upgraded mouse sensitivity stores 0.00-0.25 as a float, but the
+# in-game UI displays 0-100%. Same linear mapping for the X/Y pair and for
+# the targeting/scope sensitivities that use the "upgraded" system.
+UPGRADED_SENS_MAX = 0.25
+
+
+def sens_stored_to_pct(stored: float) -> float:
+    if stored is None:
+        return 0.0
+    return round(float(stored) / UPGRADED_SENS_MAX * 100.0, 1)
+
+
+def sens_pct_to_stored(pct: float) -> float:
+    return round(float(pct) / 100.0 * UPGRADED_SENS_MAX, 6)
+
+
+REGION_CHOICES = [
+    ("NAE", "North America East"),
+    ("NAC", "North America Central"),
+    ("NAW", "North America West"),
+    ("EU", "Europe"),
+    ("BR", "Brazil"),
+    ("OCE", "Oceania"),
+    ("ASIA", "Asia"),
+    ("ME", "Middle East"),
+]
+
+# Known enum values. For fields like VoiceChatSetting we don't have Epic's
+# official enum list, so we offer common values as suggestions but always
+# preserve whatever is currently in the file (via an editable ComboBox).
+VOICE_CHAT_SETTING_CHOICES = [
+    "ESocialCommsPermission::Nobody",
+    "ESocialCommsPermission::Friends",
+    "ESocialCommsPermission::Teammates",
+    "ESocialCommsPermission::Party",
+    "ESocialCommsPermission::Everyone",
+]
+
+VOICE_CHAT_METHOD_CHOICES = [
+    "EFortVoiceChatMethod::OpenMic",
+    "EFortVoiceChatMethod::PushToTalk",
+    "EFortVoiceChatMethod::Mute",
+]
+
+CONTROLLER_PLATFORM_CHOICES = [
+    "XboxOne",
+    "PS4",
+    "PS5",
+    "Switch",
+    "SteamDeck",
+    "Android",
+    "iOS",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fortnite FKey name mapping
+# ---------------------------------------------------------------------------
+# When the user presses a key in the capture dialog, we get a wx keycode.
+# Fortnite stores keys as UE FKey names like "SpaceBar", "LeftShift",
+# "MiddleMouseButton", "NumPadFive", "F1", "W". Map the common ones.
+
+_WX_TO_FORTNITE = {
+    wx.WXK_SPACE: "SpaceBar",
+    wx.WXK_TAB: "Tab",
+    wx.WXK_RETURN: "Enter",
+    wx.WXK_NUMPAD_ENTER: "Enter",
+    wx.WXK_BACK: "BackSpace",
+    wx.WXK_ESCAPE: "Escape",
+    wx.WXK_DELETE: "Delete",
+    wx.WXK_INSERT: "Insert",
+    wx.WXK_HOME: "Home",
+    wx.WXK_END: "End",
+    wx.WXK_PAGEUP: "PageUp",
+    wx.WXK_PAGEDOWN: "PageDown",
+    wx.WXK_UP: "Up",
+    wx.WXK_DOWN: "Down",
+    wx.WXK_LEFT: "Left",
+    wx.WXK_RIGHT: "Right",
+    wx.WXK_CAPITAL: "CapsLock",
+    wx.WXK_NUMLOCK: "NumLock",
+    wx.WXK_SCROLL: "ScrollLock",
+    wx.WXK_PAUSE: "Pause",
+
+    # Numpad digits
+    wx.WXK_NUMPAD0: "NumPadZero",
+    wx.WXK_NUMPAD1: "NumPadOne",
+    wx.WXK_NUMPAD2: "NumPadTwo",
+    wx.WXK_NUMPAD3: "NumPadThree",
+    wx.WXK_NUMPAD4: "NumPadFour",
+    wx.WXK_NUMPAD5: "NumPadFive",
+    wx.WXK_NUMPAD6: "NumPadSix",
+    wx.WXK_NUMPAD7: "NumPadSeven",
+    wx.WXK_NUMPAD8: "NumPadEight",
+    wx.WXK_NUMPAD9: "NumPadNine",
+    wx.WXK_ADD: "Add",
+    wx.WXK_SUBTRACT: "Subtract",
+    wx.WXK_MULTIPLY: "Multiply",
+    wx.WXK_DIVIDE: "Divide",
+    wx.WXK_DECIMAL: "Decimal",
+
+    # Digit row (number keys)
+    ord("0"): "Zero",
+    ord("1"): "One",
+    ord("2"): "Two",
+    ord("3"): "Three",
+    ord("4"): "Four",
+    ord("5"): "Five",
+    ord("6"): "Six",
+    ord("7"): "Seven",
+    ord("8"): "Eight",
+    ord("9"): "Nine",
+
+    # Symbols
+    ord("-"): "Hyphen",
+    ord("="): "Equals",
+    ord("["): "LeftBracket",
+    ord("]"): "RightBracket",
+    ord("\\"): "Backslash",
+    ord(";"): "Semicolon",
+    ord("'"): "Apostrophe",
+    ord(","): "Comma",
+    ord("."): "Period",
+    ord("/"): "Slash",
+    ord("`"): "Tilde",
+}
+# F-keys
+for _i in range(1, 25):
+    _WX_TO_FORTNITE[getattr(wx, f"WXK_F{_i}", -1)] = f"F{_i}"
+
+
+def wx_key_to_fortnite(key_code: int, raw_key: int = 0) -> str | None:
+    """Convert a wxPython key code to Fortnite's FKey name.
+
+    `raw_key` is the wx key code before modifiers; we use it for letters.
+    """
+    if key_code in _WX_TO_FORTNITE:
+        return _WX_TO_FORTNITE[key_code]
+    # Letter keys (A-Z come through as uppercase ordinals)
+    if ord("A") <= key_code <= ord("Z"):
+        return chr(key_code)
+    if ord("a") <= key_code <= ord("z"):
+        return chr(key_code).upper()
+    return None
+
+
+def capture_mouse_button_fortnite(code: int) -> str | None:
+    """wx mouse-button event type code -> Fortnite FKey name."""
+    # Using wx.EVT_*_DOWN event type constants; caller passes event.GetEventType().
+    if code == wx.wxEVT_LEFT_DOWN:
+        return "LeftMouseButton"
+    if code == wx.wxEVT_RIGHT_DOWN:
+        return "RightMouseButton"
+    if code == wx.wxEVT_MIDDLE_DOWN:
+        return "MiddleMouseButton"
+    if code == wx.wxEVT_AUX1_DOWN:
+        return "ThumbMouseButton"
+    if code == wx.wxEVT_AUX2_DOWN:
+        return "ThumbMouseButton2"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe(callable_, *args, **kwargs):
+    """Run `callable_(*args, **kwargs)`; return (ok, result_or_error)."""
+    try:
+        return True, callable_(*args, **kwargs)
+    except Exception as e:
+        logger.exception("clientsettings_gui error")
+        return False, e
+
+
+# ---------------------------------------------------------------------------
+# Dialog
+# ---------------------------------------------------------------------------
+
+
+class ClientSettingsEditorDialog(AccessibleDialog):
+    """Main editor dialog. Loads local settings on open."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent, title="Client Settings Editor", helpId="ClientSettingsEditor")
+
+        self.SetSize((780, 620))
+        self.SetMinSize((640, 520))
+
+        self.manager = ClientSettingsManager()
+        self.parsed: Optional[ClientSettingsFile] = None
+        self.cloud_info_text: Optional[wx.TextCtrl] = None
+        # Remember what we originally populated each control with so we can
+        # skip untouched fields on commit (avoids float32-precision drift
+        # e.g. 36.287841796875 -> "36.2878" -> 36.2878 on round-trip).
+        self._initial_text: dict[int, str] = {}
+        self._initial_check: dict[int, bool] = {}
+        self._initial_choice: dict[int, int] = {}
+
+        # Load local settings up-front; fail soft.
+        ok, result = _safe(self.manager.read_local)
+        if ok:
+            self.parsed = result
+        else:
+            wx.CallAfter(
+                messageBox,
+                message=f"Could not load ClientSettings.Sav:\n{result}\n\n"
+                        f"Expected at: {self.manager.local.primary}",
+                caption="FA11y — Client Settings",
+                style=wx.OK | wx.ICON_ERROR,
+                parent=parent,
+            )
+
+        self.setupDialog()
+
+    # ---------------------------------------------------------------- layout
+
+    def makeSettings(self, settingsSizer: BoxSizerHelper) -> None:
+        self.notebook = wx.Notebook(self)
+
+        self._build_settings_tab(self.notebook)
+        self._build_keybinds_tab(self.notebook)
+        self._build_cloud_tab(self.notebook)
+
+        settingsSizer.addItem(self.notebook, flag=wx.EXPAND, proportion=1)
+
+        bottom = ButtonHelper(wx.HORIZONTAL)
+        self.save_local_btn = bottom.addButton(self, label="Save to &Local file")
+        self.save_local_btn.Bind(wx.EVT_BUTTON, self.on_save_local)
+
+        self.save_both_btn = bottom.addButton(self, label="Save Local &and push to Cloud")
+        self.save_both_btn.Bind(wx.EVT_BUTTON, self.on_save_both)
+
+        close_btn = bottom.addButton(self, label="&Close")
+        close_btn.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
+
+        settingsSizer.addItem(bottom)
+
+        self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
+
+    # --------------------------------------------------------- settings tab
+
+    def _build_settings_tab(self, notebook: wx.Notebook) -> None:
+        panel = wx.ScrolledWindow(notebook, style=wx.VSCROLL)
+        panel.SetScrollRate(0, 12)
+        notebook.AddPage(panel, "Settings")
+
+        outer = wx.BoxSizer(wx.VERTICAL)
+
+        # --- Sensitivity group --------------------------------------------
+        sens_box = wx.StaticBox(panel, label="Sensitivity (shown as % — matches the in-game slider)")
+        sens_sizer = wx.StaticBoxSizer(sens_box, wx.VERTICAL)
+
+        self.sens_x_slider, self.sens_x_value = self._pct_slider(
+            panel, sens_sizer, "Mouse X:",
+            sens_stored_to_pct(get_value(self._props, "UpgradedMouseSensitivityX")))
+        self.sens_y_slider, self.sens_y_value = self._pct_slider(
+            panel, sens_sizer, "Mouse Y:",
+            sens_stored_to_pct(get_value(self._props, "UpgradedMouseSensitivityY")))
+        outer.Add(sens_sizer, flag=wx.EXPAND | wx.BOTTOM, border=SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
+
+        # --- Audio group --------------------------------------------------
+        audio_box = wx.StaticBox(panel, label="Audio (0–100%)")
+        audio_sizer = wx.StaticBoxSizer(audio_box, wx.VERTICAL)
+
+        self.master_slider, self.master_value = self._vol_slider(
+            panel, audio_sizer, "Master Volume:",
+            _as_float(get_value(self._props, "MasterVolume")))
+        self.music_slider, self.music_value = self._vol_slider(
+            panel, audio_sizer, "Music Volume:",
+            _as_float(get_value(self._props, "MusicVolume")))
+        self.chat_slider, self.chat_value = self._vol_slider(
+            panel, audio_sizer, "Chat Volume:",
+            _as_float(get_value(self._props, "ChatVolume")))
+        outer.Add(audio_sizer, flag=wx.EXPAND | wx.BOTTOM, border=SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
+
+        # --- Region + Voice + Controller ---------------------------------
+        pick_box = wx.StaticBox(panel, label="Region, voice chat, controller")
+        pick_sizer = wx.StaticBoxSizer(pick_box, wx.VERTICAL)
+
+        # Region: Choice (we're confident on the 8 options)
+        self.region_ctrl = self._labeled_choice(
+            panel, pick_sizer, "Region:",
+            choices=[f"{c[0]} — {c[1]}" for c in REGION_CHOICES],
+            values=[c[0] for c in REGION_CHOICES],
+            current=(get_value(self._props, "SelectedRegionId") or "NAE"),
+        )
+
+        # Voice chat setting — editable combo (preserves unknown values)
+        self.voice_setting_ctrl = self._labeled_combo(
+            panel, pick_sizer, "Voice chat permission:",
+            choices=VOICE_CHAT_SETTING_CHOICES,
+            current=get_value(self._props, "VoiceChatSetting") or "",
+        )
+        # Voice chat method — editable combo
+        self.voice_method_ctrl = self._labeled_combo(
+            panel, pick_sizer, "Voice chat method:",
+            choices=VOICE_CHAT_METHOD_CHOICES,
+            current=get_value(self._props, "VoiceChatMethod") or "",
+        )
+        # Controller platform — editable combo
+        self.controller_ctrl = self._labeled_combo(
+            panel, pick_sizer, "Controller platform:",
+            choices=CONTROLLER_PLATFORM_CHOICES,
+            current=get_value(self._props, "ControllerPlatform") or "",
+        )
+        outer.Add(pick_sizer, flag=wx.EXPAND | wx.BOTTOM, border=SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
+
+        # --- Toggles ------------------------------------------------------
+        toggles_box = wx.StaticBox(panel, label="Gameplay toggles")
+        toggles_sizer = wx.StaticBoxSizer(toggles_box, wx.VERTICAL)
+
+        self.toggles: dict[str, wx.CheckBox] = {}
+        for key, label in [
+            ("bSmartBuildEnabled",                  "Smart Build (auto-rotate building pieces)"),
+            ("bUseHoldToSwapPickup",                "Hold to swap pickup"),
+            ("bAutoOpenDoorsNonMobile",             "Auto-open doors"),
+            ("bAutoPickupWeaponsConsolePC",         "Auto-pickup weapons"),
+            ("bSwapFireInputsForDualWieldShotgunSMG", "Swap fire inputs for dual-wield"),
+            ("bAutoSortConsumablesToRight",         "Auto-sort consumables to right"),
+            ("bNewHitmarkersEnabled",               "New hitmarkers"),
+            ("bPlayerOutlinesEnabled",              "Player outlines"),
+            ("bDamageFxEnabled",                    "Damage FX"),
+            ("bHighQualityFxEnabled",               "High-quality FX"),
+            ("bRelevancyZoneVisible",               "Relevancy zone visible"),
+            ("bEnableSubtitles",                    "Subtitles"),
+            ("bEnableTextToSpeech",                 "Text-to-speech"),
+        ]:
+            cur = get_value(self._props, key)
+            if cur is None:
+                continue  # key not present in this file — hide rather than invent
+            cb = wx.CheckBox(panel, label=label)
+            val = bool(cur)
+            cb.SetValue(val)
+            self._initial_check[cb.GetId()] = val
+            toggles_sizer.Add(cb, flag=wx.ALL, border=3)
+            self.toggles[key] = cb
+        outer.Add(toggles_sizer, flag=wx.EXPAND)
+
+        panel.SetSizer(outer)
+        outer.Fit(panel)
+
+    # --------------------------------------------------------- keybinds tab
+
+    def _build_keybinds_tab(self, notebook: wx.Notebook) -> None:
+        panel = wx.Panel(notebook)
+        notebook.AddPage(panel, "Keybinds")
+
+        outer = wx.BoxSizer(wx.VERTICAL)
+
+        # sub-game selector
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        row.Add(wx.StaticText(panel, label="Sub-game:"), flag=wx.ALIGN_CENTER_VERTICAL)
+        row.AddSpacer(10)
+        self.sub_game_ctrl = wx.Choice(
+            panel,
+            choices=["ESubGame::Athena (Battle Royale)",
+                     "ESubGame::Campaign (Save the World)",
+                     "ESubGame::Invalid (shared)"],
+        )
+        self.sub_game_ctrl.SetSelection(0)
+        self.sub_game_ctrl.Bind(wx.EVT_CHOICE, self._on_subgame_changed)
+        row.Add(self.sub_game_ctrl)
+        outer.Add(row, flag=wx.EXPAND | wx.ALL, border=4)
+
+        # filter
+        row2 = wx.BoxSizer(wx.HORIZONTAL)
+        row2.Add(wx.StaticText(panel, label="Filter:"), flag=wx.ALIGN_CENTER_VERTICAL)
+        row2.AddSpacer(10)
+        self.filter_ctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER)
+        self.filter_ctrl.Bind(wx.EVT_TEXT, lambda _: self._refresh_keybinds())
+        row2.Add(self.filter_ctrl, proportion=1, flag=wx.EXPAND)
+        self.hide_unbound = wx.CheckBox(panel, label="Hide unbound")
+        self.hide_unbound.SetValue(True)
+        self.hide_unbound.Bind(wx.EVT_CHECKBOX, lambda _: self._refresh_keybinds())
+        row2.AddSpacer(10)
+        row2.Add(self.hide_unbound, flag=wx.ALIGN_CENTER_VERTICAL)
+        outer.Add(row2, flag=wx.EXPAND | wx.ALL, border=4)
+
+        # list
+        self.kb_list = wx.ListCtrl(panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+        self.kb_list.InsertColumn(0, "Action", width=260)
+        self.kb_list.InsertColumn(1, "Key 1", width=140)
+        self.kb_list.InsertColumn(2, "Key 2", width=140)
+        self.kb_list.InsertColumn(3, "Axis?", width=60)
+        self.kb_list.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_edit_keybind)
+        outer.Add(self.kb_list, proportion=1, flag=wx.EXPAND | wx.ALL, border=4)
+
+        # edit button
+        self.edit_btn = wx.Button(panel, label="&Edit selected binding…")
+        self.edit_btn.Bind(wx.EVT_BUTTON, self._on_edit_keybind)
+        outer.Add(self.edit_btn, flag=wx.ALL, border=4)
+
+        help_lbl = wx.StaticText(
+            panel,
+            label=("Double-click a row to edit its key(s). Use UE key names like W, A, S, D, SpaceBar, "
+                   "LeftShift, LeftControl, LeftAlt, RightMouseButton, ThumbMouseButton. 'None' unbinds."),
+        )
+        help_lbl.Wrap(720)
+        outer.Add(help_lbl, flag=wx.ALL, border=4)
+
+        panel.SetSizer(outer)
+        self._refresh_keybinds()
+
+    def _current_sub_game(self) -> str:
+        return ["ESubGame::Athena", "ESubGame::Campaign", "ESubGame::Invalid"][self.sub_game_ctrl.GetSelection()]
+
+    def _on_subgame_changed(self, _evt: wx.CommandEvent) -> None:
+        self._refresh_keybinds()
+
+    def _refresh_keybinds(self) -> None:
+        self.kb_list.DeleteAllItems()
+        if self.parsed is None:
+            return
+        binds = ClientSettingsManager.get_keybinds(self.parsed, sub_game=self._current_sub_game())
+        filt = (self.filter_ctrl.GetValue() or "").lower().strip()
+        hide_unbound = self.hide_unbound.GetValue()
+        count = 0
+        for b in binds:
+            if hide_unbound and (b["key1"] in (None, "None")) and (b["key2"] in (None, "None")):
+                continue
+            if filt and filt not in (b.get("action") or "").lower():
+                continue
+            idx = self.kb_list.InsertItem(count, b.get("action") or "")
+            self.kb_list.SetItem(idx, 1, str(b.get("key1") or ""))
+            self.kb_list.SetItem(idx, 2, str(b.get("key2") or ""))
+            self.kb_list.SetItem(idx, 3, "yes" if b.get("is_axis") else "")
+            count += 1
+
+    def _on_edit_keybind(self, _evt) -> None:
+        sel = self.kb_list.GetFirstSelected()
+        if sel < 0:
+            speaker.speak("No binding selected")
+            return
+        action = self.kb_list.GetItemText(sel, 0)
+        key1 = self.kb_list.GetItemText(sel, 1)
+        key2 = self.kb_list.GetItemText(sel, 2)
+
+        dlg = _KeybindEditDialog(self, action=action, key1=key1, key2=key2)
+        if dlg.ShowModal() == wx.ID_OK:
+            new1, new2 = dlg.get_values()
+            hits = ClientSettingsManager.set_keybind(
+                self.parsed, action,
+                key1=new1, key2=new2,
+                sub_game=self._current_sub_game(),
+            )
+            if hits == 0:
+                speaker.speak(f"No binding matched {action}")
+            else:
+                speaker.speak(f"{action} updated — remember to save")
+                self._refresh_keybinds()
+        dlg.Destroy()
+
+    # ------------------------------------------------------------- cloud tab
+
+    def _build_cloud_tab(self, notebook: wx.Notebook) -> None:
+        panel = wx.Panel(notebook)
+        notebook.AddPage(panel, "Cloud")
+
+        outer = wx.BoxSizer(wx.VERTICAL)
+
+        info = wx.StaticText(
+            panel,
+            label=(
+                "Fortnite stores your settings on Epic's cloud so they follow you across devices.\n\n"
+                "Push = upload YOUR local file to the cloud (Fortnite reads this on its next launch).\n"
+                "Pull = download the cloud copy over your local file (requires Fortnite closed).\n"
+                "Diff = show where the local and cloud copies differ."
+            ),
+        )
+        info.Wrap(720)
+        outer.Add(info, flag=wx.ALL, border=6)
+
+        self.cloud_info_text = wx.TextCtrl(
+            panel, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL,
+            size=(-1, 260),
+        )
+        outer.Add(self.cloud_info_text, proportion=1, flag=wx.EXPAND | wx.ALL, border=6)
+
+        btns = ButtonHelper(wx.HORIZONTAL)
+        b1 = btns.addButton(panel, label="Refresh cloud &info")
+        b1.Bind(wx.EVT_BUTTON, lambda _: self._refresh_cloud_info())
+
+        b2 = btns.addButton(panel, label="&Push local → cloud")
+        b2.Bind(wx.EVT_BUTTON, lambda _: self._cloud_action_push())
+
+        b3 = btns.addButton(panel, label="P&ull cloud → local")
+        b3.Bind(wx.EVT_BUTTON, lambda _: self._cloud_action_pull())
+
+        b4 = btns.addButton(panel, label="&Diff local vs cloud")
+        b4.Bind(wx.EVT_BUTTON, lambda _: self._cloud_action_diff())
+        outer.Add(btns.sizer, flag=wx.ALL, border=6)
+
+        panel.SetSizer(outer)
+        wx.CallAfter(self._refresh_cloud_info)
+
+    def _log(self, line: str) -> None:
+        if self.cloud_info_text is None:
+            return
+        wx.CallAfter(self.cloud_info_text.AppendText, line + "\n")
+
+    def _refresh_cloud_info(self) -> None:
+        self._log("--- refreshing ---")
+
+        def worker():
+            try:
+                files = self.manager.cloud.list_files()
+            except Exception as e:
+                self._log(f"ERROR: {e}")
+                return
+            sav = next((f for f in files if f.unique_filename == CLIENT_SETTINGS_FILENAME), None)
+            if sav is None:
+                self._log("No ClientSettings.Sav on the cloud for this account yet.")
+                return
+            self._log(f"cloud file: {sav.unique_filename}")
+            self._log(f"  size:     {sav.length} bytes")
+            self._log(f"  uploaded: {sav.uploaded}")
+            self._log(f"  hash:     {sav.hash}")
+
+            local_path = self.manager.local.primary
+            if local_path.exists():
+                self._log(f"local file: {local_path}")
+                self._log(f"  size:     {local_path.stat().st_size} bytes")
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _cloud_action_push(self) -> None:
+        if self.parsed is None:
+            speaker.speak("Nothing to push — no local file loaded")
+            return
+        # Apply pending UI edits into self.parsed first
+        ok, err = _safe(self._commit_form_to_parsed)
+        if not ok:
+            self._log(f"ERROR applying form changes: {err}")
+            return
+
+        data = serialize_file(self.parsed)
+
+        def worker():
+            try:
+                self.manager.cloud.upload(CLIENT_SETTINGS_FILENAME, data)
+            except Exception as e:
+                self._log(f"PUSH ERROR: {e}")
+                wx.CallAfter(speaker.speak, "Push failed")
+                return
+            self._log(f"Pushed {len(data)} bytes to cloud.")
+            wx.CallAfter(speaker.speak, "Pushed to cloud")
+            wx.CallAfter(self._refresh_cloud_info)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _cloud_action_pull(self) -> None:
+        if is_fortnite_running():
+            messageBox(
+                "Fortnite is running and holds a lock on the save file.\n"
+                "Close Fortnite before pulling.",
+                caption="FA11y — Client Settings",
+                style=wx.OK | wx.ICON_WARNING, parent=self,
+            )
+            return
+
+        def worker():
+            try:
+                target = self.manager.pull_from_cloud(require_game_closed=True)
+            except Exception as e:
+                self._log(f"PULL ERROR: {e}")
+                wx.CallAfter(speaker.speak, "Pull failed")
+                return
+            self._log(f"Wrote cloud copy to {target}")
+            # Re-read so the form reflects the new local state
+            ok, result = _safe(self.manager.read_local)
+            if ok:
+                self.parsed = result
+                wx.CallAfter(self._reload_form_from_parsed)
+                wx.CallAfter(speaker.speak, "Pulled cloud copy onto local file")
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _cloud_action_diff(self) -> None:
+        def worker():
+            try:
+                local = self.parsed or self.manager.read_local()
+                cloud = self.manager.read_cloud()
+            except Exception as e:
+                self._log(f"DIFF ERROR: {e}")
+                return
+
+            d = diff_settings(local, cloud)
+            self._log(f"--- diff: {d.summary()} ---")
+            if d.only_local:
+                self._log(f"only local ({len(d.only_local)}): {', '.join(d.only_local[:12])}"
+                          + (" ..." if len(d.only_local) > 12 else ""))
+            if d.only_cloud:
+                self._log(f"only cloud ({len(d.only_cloud)}): {', '.join(d.only_cloud[:12])}"
+                          + (" ..." if len(d.only_cloud) > 12 else ""))
+            for row in d.different[:30]:
+                self._log(f"  {row['name']}")
+                self._log(f"    local: {str(row['local'])[:120]}")
+                self._log(f"    cloud: {str(row['cloud'])[:120]}")
+            if len(d.different) > 30:
+                self._log(f"  ... ({len(d.different) - 30} more differences)")
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    # ----------------------------------------------------------------- save
+
+    def on_save_local(self, _evt: wx.CommandEvent) -> None:
+        if self.parsed is None:
+            return
+        ok, err = _safe(self._commit_form_to_parsed)
+        if not ok:
+            messageBox(f"Validation error:\n{err}", style=wx.OK | wx.ICON_ERROR, parent=self)
+            return
+        if is_fortnite_running():
+            if messageBox(
+                "Fortnite is running. Save anyway? (The game holds a lock — this will fail unless you close it first.)",
+                caption="FA11y — Client Settings",
+                style=wx.YES_NO | wx.ICON_WARNING, parent=self,
+            ) != wx.YES:
+                return
+        ok, err = _safe(self.manager.write_local, self.parsed, require_game_closed=False)
+        if not ok:
+            messageBox(f"Save failed:\n{err}", style=wx.OK | wx.ICON_ERROR, parent=self)
+            return
+        speaker.speak("Saved to local file")
+        self._log(f"Saved to {self.manager.local.primary}")
+
+    def on_save_both(self, _evt: wx.CommandEvent) -> None:
+        if self.parsed is None:
+            return
+        self.on_save_local(_evt)
+        self._cloud_action_push()
+
+    # -------------------------------------------------------------- plumbing
+
+    @property
+    def _props(self) -> list:
+        return self.parsed.properties if self.parsed is not None else []
+
+    def _labeled_float(self, parent, parent_sizer, label, current) -> wx.TextCtrl:
+        ctrl = _add_labeled_float(parent, parent_sizer, label, current)
+        self._initial_text[ctrl.GetId()] = ctrl.GetValue()
+        return ctrl
+
+    def _pct_slider(self, parent, parent_sizer, label, current_pct) -> tuple[wx.Slider, wx.StaticText]:
+        """0-100 % slider with live numeric label."""
+        return self._slider(parent, parent_sizer, label, current_pct, lo=0, hi=100, fmt="{:.0f}%")
+
+    def _vol_slider(self, parent, parent_sizer, label, current_0_1) -> tuple[wx.Slider, wx.StaticText]:
+        """0.0-1.0 volume slider shown as 0-100% internally."""
+        return self._slider(parent, parent_sizer, label, current_0_1 * 100.0, lo=0, hi=100, fmt="{:.0f}%")
+
+    def _slider(self, parent, parent_sizer, label, current, lo, hi, fmt):
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        row.Add(wx.StaticText(parent, label=label, size=(180, -1)), flag=wx.ALIGN_CENTER_VERTICAL)
+
+        initial = max(lo, min(hi, int(round(float(current or 0)))))
+        slider = wx.Slider(parent, value=initial, minValue=lo, maxValue=hi,
+                           style=wx.SL_HORIZONTAL, size=(240, -1))
+        value_label = wx.StaticText(parent, label=fmt.format(slider.GetValue()), size=(64, -1))
+
+        def _on_scroll(evt):
+            value_label.SetLabel(fmt.format(slider.GetValue()))
+            evt.Skip()
+        slider.Bind(wx.EVT_SLIDER, _on_scroll)
+
+        row.Add(slider, proportion=1, flag=wx.ALIGN_CENTER_VERTICAL)
+        row.AddSpacer(6)
+        row.Add(value_label, flag=wx.ALIGN_CENTER_VERTICAL)
+        parent_sizer.Add(row, flag=wx.EXPAND | wx.ALL, border=4)
+
+        self._initial_slider_value = getattr(self, "_initial_slider_value", {})
+        self._initial_slider_value[slider.GetId()] = initial
+        return slider, value_label
+
+    def _labeled_choice(self, parent, parent_sizer, label, choices, values, current) -> wx.Choice:
+        """Labeled Choice where `values[i]` is the stored value for display `choices[i]`."""
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        row.Add(wx.StaticText(parent, label=label, size=(180, -1)), flag=wx.ALIGN_CENTER_VERTICAL)
+        ctrl = wx.Choice(parent, choices=choices)
+        try:
+            idx = values.index(current)
+        except ValueError:
+            idx = 0
+        ctrl.SetSelection(idx)
+        ctrl._fa11y_values = values  # attach for commit
+        self._initial_choice[ctrl.GetId()] = idx
+        row.Add(ctrl, proportion=1)
+        parent_sizer.Add(row, flag=wx.EXPAND | wx.ALL, border=4)
+        return ctrl
+
+    def _labeled_combo(self, parent, parent_sizer, label, choices, current) -> wx.ComboBox:
+        """Editable ComboBox — preserves unknown current values (they go in the text)."""
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        row.Add(wx.StaticText(parent, label=label, size=(180, -1)), flag=wx.ALIGN_CENTER_VERTICAL)
+        ctrl = wx.ComboBox(parent, value=str(current or ""), choices=list(choices),
+                           style=wx.CB_DROPDOWN)  # editable; not CB_READONLY
+        self._initial_text[ctrl.GetId()] = ctrl.GetValue()
+        row.Add(ctrl, proportion=1, flag=wx.EXPAND)
+        parent_sizer.Add(row, flag=wx.EXPAND | wx.ALL, border=4)
+        return ctrl
+
+    def _text_changed(self, ctrl) -> bool:
+        """True if a TextCtrl or ComboBox value differs from what we loaded."""
+        return ctrl.GetValue() != self._initial_text.get(ctrl.GetId(), "")
+
+    def _check_changed(self, cb: wx.CheckBox) -> bool:
+        return cb.GetValue() != self._initial_check.get(cb.GetId(), cb.GetValue())
+
+    def _choice_changed(self, ch: wx.Choice) -> bool:
+        return ch.GetSelection() != self._initial_choice.get(ch.GetId(), ch.GetSelection())
+
+    def _slider_changed(self, sl: wx.Slider) -> bool:
+        initial = getattr(self, "_initial_slider_value", {}).get(sl.GetId(), sl.GetValue())
+        return sl.GetValue() != initial
+
+    def _commit_form_to_parsed(self) -> None:
+        """Read UI controls and mutate self.parsed in place.
+
+        Only writes fields the user actually modified, so unchanged values
+        keep their original float32 bit pattern (avoids precision drift from
+        the display round-trip).
+        """
+        if self.parsed is None:
+            raise RuntimeError("no file loaded")
+
+        # Sensitivity sliders (percent -> stored 0.0-0.25)
+        if self._slider_changed(self.sens_x_slider):
+            set_value(self._props, "UpgradedMouseSensitivityX",
+                      sens_pct_to_stored(self.sens_x_slider.GetValue()))
+        if self._slider_changed(self.sens_y_slider):
+            set_value(self._props, "UpgradedMouseSensitivityY",
+                      sens_pct_to_stored(self.sens_y_slider.GetValue()))
+
+        # Audio sliders (0-100 -> stored 0.0-1.0)
+        for slider, key in ((self.master_slider, "MasterVolume"),
+                            (self.music_slider, "MusicVolume"),
+                            (self.chat_slider, "ChatVolume")):
+            if self._slider_changed(slider):
+                set_value(self._props, key, slider.GetValue() / 100.0)
+
+        # Region (Choice)
+        if self._choice_changed(self.region_ctrl):
+            values = getattr(self.region_ctrl, "_fa11y_values", None)
+            sel = self.region_ctrl.GetSelection()
+            if values and 0 <= sel < len(values):
+                set_value(self._props, "SelectedRegionId", values[sel])
+
+        # Voice chat + controller (editable ComboBoxes)
+        for ctrl, key in ((self.voice_setting_ctrl, "VoiceChatSetting"),
+                          (self.voice_method_ctrl, "VoiceChatMethod"),
+                          (self.controller_ctrl, "ControllerPlatform")):
+            if self._text_changed(ctrl):
+                val = ctrl.GetValue().strip()
+                if val:
+                    set_value(self._props, key, val)
+
+        # Toggles
+        for key, cb in self.toggles.items():
+            if self._check_changed(cb):
+                set_value(self._props, key, bool(cb.GetValue()))
+
+    def _reload_form_from_parsed(self) -> None:
+        if self.parsed is None:
+            return
+
+        def set_text(ctrl, text: str) -> None:
+            ctrl.SetValue(text)
+            self._initial_text[ctrl.GetId()] = text
+
+        def set_slider_pct(slider, label_ctrl, pct: float, fmt="{:.0f}%") -> None:
+            v = max(0, min(100, int(round(pct))))
+            slider.SetValue(v)
+            label_ctrl.SetLabel(fmt.format(v))
+            self._initial_slider_value[slider.GetId()] = v
+
+        set_slider_pct(self.sens_x_slider, self.sens_x_value,
+                       sens_stored_to_pct(get_value(self._props, "UpgradedMouseSensitivityX")))
+        set_slider_pct(self.sens_y_slider, self.sens_y_value,
+                       sens_stored_to_pct(get_value(self._props, "UpgradedMouseSensitivityY")))
+        set_slider_pct(self.master_slider, self.master_value,
+                       _as_float(get_value(self._props, "MasterVolume")) * 100)
+        set_slider_pct(self.music_slider, self.music_value,
+                       _as_float(get_value(self._props, "MusicVolume")) * 100)
+        set_slider_pct(self.chat_slider, self.chat_value,
+                       _as_float(get_value(self._props, "ChatVolume")) * 100)
+
+        # Region Choice
+        current_region = get_value(self._props, "SelectedRegionId") or "NAE"
+        try:
+            idx = [c[0] for c in REGION_CHOICES].index(current_region)
+            self.region_ctrl.SetSelection(idx)
+            self._initial_choice[self.region_ctrl.GetId()] = idx
+        except ValueError:
+            pass
+
+        # ComboBoxes
+        for ctrl, key in ((self.voice_setting_ctrl, "VoiceChatSetting"),
+                          (self.voice_method_ctrl, "VoiceChatMethod"),
+                          (self.controller_ctrl, "ControllerPlatform")):
+            set_text(ctrl, get_value(self._props, key) or "")
+
+        # Toggles
+        for key, cb in self.toggles.items():
+            val = bool(get_value(self._props, key))
+            cb.SetValue(val)
+            self._initial_check[cb.GetId()] = val
+
+        self._refresh_keybinds()
+
+    def _on_char_hook(self, event: wx.KeyEvent) -> None:
+        if event.GetKeyCode() == wx.WXK_ESCAPE:
+            self.Close()
+            return
+        event.Skip()
+
+
+# ---------------------------------------------------------------------------
+# Keybind edit dialog
+# ---------------------------------------------------------------------------
+
+
+class _KeybindEditDialog(wx.Dialog):
+    """Press-to-capture binding editor.
+
+    Matches FA11y's existing config-GUI keybind button flow: user clicks the
+    slot they want to rebind ("Press a key..."), then physically presses the
+    key / mouse button they want. Escape cancels that slot's capture.
+    Delete / Backspace clears the slot (sets to "None").
+    """
+
+    def __init__(self, parent, *, action: str, key1: str, key2: str):
+        super().__init__(parent, title=f"Edit binding — {action}")
+        self.action = action
+        self._capturing_slot: int | None = None  # 1 or 2 while capturing
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(wx.StaticText(self, label=f"Action: {action}"),
+                  flag=wx.ALL, border=8)
+        sizer.Add(wx.StaticText(
+            self,
+            label=("Click a slot button, then press the key you want.\n"
+                   "Keyboard keys, all five mouse buttons (left, right, middle, "
+                   "back=4, forward=5) and the scroll wheel (up/down) are all "
+                   "accepted.\n"
+                   "Escape = cancel this capture. Delete / Backspace = unbind."),
+        ), flag=wx.ALL, border=8)
+
+        g = wx.FlexGridSizer(cols=2, hgap=10, vgap=8)
+        g.Add(wx.StaticText(self, label="Key 1 (primary):"), flag=wx.ALIGN_CENTER_VERTICAL)
+        self.k1_btn = wx.Button(self, label=key1 or "None")
+        self.k1_btn.Bind(wx.EVT_BUTTON, lambda _: self._start_capture(1))
+        g.Add(self.k1_btn, flag=wx.EXPAND)
+
+        g.Add(wx.StaticText(self, label="Key 2 (secondary):"), flag=wx.ALIGN_CENTER_VERTICAL)
+        self.k2_btn = wx.Button(self, label=key2 or "None")
+        self.k2_btn.Bind(wx.EVT_BUTTON, lambda _: self._start_capture(2))
+        g.Add(self.k2_btn, flag=wx.EXPAND)
+        g.AddGrowableCol(1)
+        sizer.Add(g, flag=wx.EXPAND | wx.ALL, border=8)
+
+        btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        sizer.Add(btn_sizer, flag=wx.EXPAND | wx.ALL, border=8)
+
+        self.SetSizer(sizer)
+        self.Fit()
+
+        # Key / mouse capture bindings at the dialog level so they fire
+        # regardless of which child has focus while capturing.
+        self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
+        # One catch-all for mouse events — some wx builds don't expose
+        # EVT_AUX1_DOWN / EVT_AUX2_DOWN as binder names.
+        self.Bind(wx.EVT_MOUSE_EVENTS, self._on_mouse_event)
+        # Scroll wheel is a separate event type.
+        self.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
+
+    # ------------------------------------------------------------------
+
+    def _slot_btn(self, slot: int) -> wx.Button:
+        return self.k1_btn if slot == 1 else self.k2_btn
+
+    def _start_capture(self, slot: int) -> None:
+        self._capturing_slot = slot
+        btn = self._slot_btn(slot)
+        btn._pre_capture_label = btn.GetLabel()
+        btn.SetLabel(f"Press a key for slot {slot}… (Esc cancels, Del unbinds)")
+        speaker.speak(f"Press a key for slot {slot}")
+
+    def _finish_capture(self, value: str | None) -> None:
+        if self._capturing_slot is None:
+            return
+        btn = self._slot_btn(self._capturing_slot)
+        if value is not None:
+            btn.SetLabel(value)
+            speaker.speak(f"Bound to {value}")
+        else:
+            # restore original label
+            btn.SetLabel(getattr(btn, "_pre_capture_label", "None"))
+        self._capturing_slot = None
+
+    def _on_char_hook(self, evt: wx.KeyEvent) -> None:
+        if self._capturing_slot is None:
+            evt.Skip()
+            return
+        code = evt.GetKeyCode()
+        if code == wx.WXK_ESCAPE:
+            self._finish_capture(None)
+            return
+        if code in (wx.WXK_DELETE, wx.WXK_BACK):
+            self._finish_capture("None")
+            return
+        # Ignore bare modifier keydowns — they'd be useless as standalone binds
+        if code in (wx.WXK_SHIFT, wx.WXK_CONTROL, wx.WXK_ALT,
+                    wx.WXK_RAW_CONTROL, wx.WXK_WINDOWS_LEFT, wx.WXK_WINDOWS_RIGHT):
+            # But Fortnite does support LeftShift etc. as standalone keys, so
+            # use GetRawKeyCode / position to decide left vs right where we can.
+            # wx doesn't distinguish left/right reliably here; treat bare
+            # modifier as its "Left" variant by default.
+            name = {
+                wx.WXK_SHIFT: "LeftShift",
+                wx.WXK_CONTROL: "LeftControl",
+                wx.WXK_ALT: "LeftAlt",
+                wx.WXK_RAW_CONTROL: "LeftControl",
+                wx.WXK_WINDOWS_LEFT: "LeftCommand",
+                wx.WXK_WINDOWS_RIGHT: "RightCommand",
+            }.get(code)
+            if name:
+                self._finish_capture(name)
+                return
+            evt.Skip()
+            return
+        name = wx_key_to_fortnite(code)
+        if name is None:
+            speaker.speak("Unsupported key — try another")
+            return
+        self._finish_capture(name)
+
+    def _on_mouse_event(self, evt: wx.MouseEvent) -> None:
+        if self._capturing_slot is None:
+            evt.Skip()
+            return
+        # Only react on the *_DOWN phase. Up/motion/etc. skip.
+        # Mouse button numbering (matches Windows / most gaming mice):
+        #   Button 1 = Left,  Button 2 = Right,       Button 3 = Middle,
+        #   Button 4 = Back (Aux1),  Button 5 = Forward (Aux2).
+        if evt.LeftDown():
+            self._finish_capture("LeftMouseButton"); return
+        if evt.RightDown():
+            self._finish_capture("RightMouseButton"); return
+        if evt.MiddleDown():
+            self._finish_capture("MiddleMouseButton"); return
+        if hasattr(evt, "Aux1Down") and evt.Aux1Down():
+            self._finish_capture("ThumbMouseButton"); return
+        if hasattr(evt, "Aux2Down") and evt.Aux2Down():
+            self._finish_capture("ThumbMouseButton2"); return
+        evt.Skip()
+
+    def _on_mouse_wheel(self, evt: wx.MouseEvent) -> None:
+        if self._capturing_slot is None:
+            evt.Skip()
+            return
+        rot = evt.GetWheelRotation()
+        if rot > 0:
+            self._finish_capture("MouseScrollUp")
+        elif rot < 0:
+            self._finish_capture("MouseScrollDown")
+        else:
+            evt.Skip()
+
+    def get_values(self) -> tuple[str | None, str | None]:
+        v1 = self.k1_btn.GetLabel().strip() or None
+        v2 = self.k2_btn.GetLabel().strip() or None
+        if v1 and v1.lower() == "none":
+            v1 = "None"
+        if v2 and v2.lower() == "none":
+            v2 = "None"
+        # Sanitize accidental "Press a key..." prompt text if user clicks OK mid-capture
+        for v in (v1, v2):
+            pass
+        if v1 and v1.startswith("Press a key"):
+            v1 = None
+        if v2 and v2.startswith("Press a key"):
+            v2 = None
+        return v1, v2
+
+
+# ---------------------------------------------------------------------------
+# Small helpers for controls
+# ---------------------------------------------------------------------------
+
+
+def _add_labeled_float(parent: wx.Window, parent_sizer: wx.Sizer,
+                       label: str, current: float) -> wx.TextCtrl:
+    row = wx.BoxSizer(wx.HORIZONTAL)
+    row.Add(wx.StaticText(parent, label=label, size=(200, -1)),
+            flag=wx.ALIGN_CENTER_VERTICAL)
+    ctrl = wx.TextCtrl(parent, value=_fmt_float(current), size=(120, -1),
+                       style=wx.TE_PROCESS_ENTER)
+    row.Add(ctrl)
+    parent_sizer.Add(row, flag=wx.ALL, border=4)
+    return ctrl
+
+
+def _read_float_ctrl(ctrl: wx.TextCtrl, name: str) -> float:
+    raw = (ctrl.GetValue() or "").strip()
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(f"{name}: expected a number, got {raw!r}")
+
+
+def _clamp(v: float, lo: float, hi: float, name: str) -> None:
+    if not (lo <= v <= hi):
+        raise ValueError(f"{name}: value {v} outside range [{lo}, {hi}]")
+
+
+def _as_float(v: Any) -> float:
+    if v is None:
+        return 0.0
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _fmt_float(v: float) -> str:
+    if v is None:
+        return ""
+    if float(v).is_integer():
+        return str(int(v))
+    return f"{v:g}"
+
+
+# ---------------------------------------------------------------------------
+# Public launcher
+# ---------------------------------------------------------------------------
+
+
+def launch_clientsettings_editor() -> None:
+    """Create and show the dialog on the main thread."""
+    def _do_launch():
+        app = wx.GetApp()
+        if app is None:
+            speaker.speak("GUI unavailable")
+            return
+        dlg = ClientSettingsEditorDialog(None)
+        dlg.ShowModal()
+        dlg.Destroy()
+
+    launch_gui_thread_safe(_do_launch)

--- a/lib/utilities/clientsettings_cli.py
+++ b/lib/utilities/clientsettings_cli.py
@@ -1,0 +1,194 @@
+"""
+Command-line interface for FA11y's ClientSettings.Sav integration.
+
+Uses FA11y's cached EpicAuth so no separate login is needed. Run from the
+repo root:
+
+    python -m lib.utilities.clientsettings_cli <subcommand> [args]
+
+Subcommands:
+    list                        list files in cloud storage
+    show [path]                 parse a local/cloud save and print summary
+    diff                        structural diff: local vs cloud ClientSettings.Sav
+    pull                        cloud -> local (requires game closed)
+    push                        local -> cloud (Fortnite can be running)
+    keybinds [sub_game]         print current bindings (default ESubGame::Athena)
+    set-keybind ACTION KEY      set KeyBind1 of an action, push to cloud
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from lib.utilities.clientsettings_parser import parse_file, serialize_file
+from lib.utilities.clientsettings_sync import (
+    CLIENT_SETTINGS_FILENAME,
+    ClientSettingsManager,
+    locate_local,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _cmd_list(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    files = mgr.cloud.list_files(include_restricted=args.all)
+    print(f"{len(files)} files on this Epic account:")
+    for f in files:
+        print(f"  {f.unique_filename:45s}  {f.length:>8d} B  {f.uploaded}")
+    return 0
+
+
+def _cmd_show(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    if args.path:
+        data = Path(args.path).read_bytes()
+    else:
+        data = mgr.local.primary.read_bytes()
+    parsed = parse_file(data)
+
+    print(f"was_compressed:   {parsed.was_compressed}")
+    print(f"header bytes:     {len(parsed.stream.header_bytes)}")
+    print(f"top-level props:  {len(parsed.stream.properties)}")
+
+    interesting = [
+        "MouseSensitivity", "UpgradedMouseSensitivityX", "UpgradedMouseSensitivityY",
+        "FocalLength", "MasterVolume", "MusicVolume", "ChatVolume",
+        "VoiceChatSetting", "VoiceChatMethod", "bEnableSubtitles",
+        "SelectedRegionId", "InputPresetNameForAthena", "ControllerPlatform",
+        "bSmartBuildEnabled", "EditButtonHoldTime", "bNewHitmarkersEnabled",
+    ]
+    print("\nCommonly-adjusted settings:")
+    for k in interesting:
+        v = mgr.get(parsed, k)
+        if v is not None:
+            print(f"  {k:32s} = {v!r}")
+    return 0
+
+
+def _cmd_diff(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    d = mgr.compare()
+    print(d.summary())
+    if d.only_local:
+        print("\nonly local:")
+        for k in d.only_local:
+            print(f"  {k}")
+    if d.only_cloud:
+        print("\nonly cloud:")
+        for k in d.only_cloud:
+            print(f"  {k}")
+    if d.different:
+        print(f"\n{len(d.different)} differences:")
+        for row in d.different[:50]:
+            print(f"  {row['name']}")
+            loc = json.dumps(row['local'], default=str)[:160]
+            rem = json.dumps(row['cloud'], default=str)[:160]
+            print(f"    local: {loc}")
+            print(f"    cloud: {rem}")
+        if len(d.different) > 50:
+            print(f"  ... ({len(d.different) - 50} more, use --all to show)")
+    return 0
+
+
+def _cmd_pull(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    dest = mgr.pull_from_cloud(require_game_closed=not args.force)
+    print(f"wrote cloud copy to {dest}")
+    return 0
+
+
+def _cmd_push(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    n = mgr.push_to_cloud()
+    print(f"pushed {n} bytes -> cloud ClientSettings.Sav")
+    return 0
+
+
+def _cmd_keybinds(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    parsed = mgr.read_local()
+    binds = ClientSettingsManager.get_keybinds(parsed, sub_game=args.sub_game)
+    print(f"{len(binds)} bindings in {args.sub_game}:")
+    for b in binds:
+        if b["key1"] == "None" and b["key2"] == "None":
+            continue
+        keys = b["key1"] if b["key2"] == "None" else f"{b['key1']} / {b['key2']}"
+        suffix = ""
+        if b["is_axis"]:
+            suffix = f"  (axis, scale={b['input_scale']})"
+        print(f"  {b['action']:40s} -> {keys}{suffix}")
+    return 0
+
+
+def _cmd_set_keybind(args: argparse.Namespace, mgr: ClientSettingsManager) -> int:
+    parsed = mgr.read_local()
+    hits = ClientSettingsManager.set_keybind(
+        parsed, args.action, key1=args.key, sub_game=args.sub_game
+    )
+    if hits == 0:
+        print(f"no binding matched action={args.action!r} in {args.sub_game}", file=sys.stderr)
+        return 1
+    print(f"updated {hits} binding(s): {args.action} -> {args.key}")
+
+    if args.local_only:
+        mgr.write_local(parsed, require_game_closed=not args.force)
+        print(f"wrote local file")
+    elif args.cloud_only:
+        mgr.cloud.upload(CLIENT_SETTINGS_FILENAME, serialize_file(parsed))
+        print("uploaded to cloud")
+    else:
+        result = mgr.apply_changes(parsed, push_cloud=True, write_local=True,
+                                   require_game_closed=not args.force)
+        print(json.dumps(result, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="clientsettings_cli")
+    ap.add_argument("--debug", action="store_true", help="verbose logging")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("list", help="list cloud storage files")
+    p.add_argument("--all", action="store_true", help="include restricted files")
+
+    p = sub.add_parser("show", help="parse and summarize a save file")
+    p.add_argument("path", nargs="?", help="path (default: local Config/ClientSettings.Sav)")
+
+    sub.add_parser("diff", help="local vs cloud structural diff")
+
+    p = sub.add_parser("pull", help="download cloud ClientSettings.Sav and replace local")
+    p.add_argument("--force", action="store_true", help="skip the game-is-closed check")
+
+    sub.add_parser("push", help="upload local ClientSettings.Sav to cloud")
+
+    p = sub.add_parser("keybinds", help="print bindings for a sub-game")
+    p.add_argument("sub_game", nargs="?", default="ESubGame::Athena")
+
+    p = sub.add_parser("set-keybind", help="change a binding's primary key (KeyBind1)")
+    p.add_argument("action", help="action name, e.g. 'Jump'")
+    p.add_argument("key", help="key name, e.g. 'V', 'SpaceBar', 'LeftShift'")
+    p.add_argument("--sub-game", default="ESubGame::Athena")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--local-only", action="store_true", help="write local only, don't push cloud")
+    mode.add_argument("--cloud-only", action="store_true", help="push cloud only, don't write local")
+    p.add_argument("--force", action="store_true", help="skip the game-is-closed check")
+
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    mgr = ClientSettingsManager()
+
+    dispatch = {
+        "list": _cmd_list,
+        "show": _cmd_show,
+        "diff": _cmd_diff,
+        "pull": _cmd_pull,
+        "push": _cmd_push,
+        "keybinds": _cmd_keybinds,
+        "set-keybind": _cmd_set_keybind,
+    }
+    return dispatch[args.cmd](args, mgr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/utilities/clientsettings_cloud.py
+++ b/lib/utilities/clientsettings_cloud.py
@@ -1,0 +1,219 @@
+"""
+Fortnite cloud storage client for user settings files.
+
+Wraps the `/fortnite/api/cloudstorage/user/{accountId}` endpoint so FA11y can
+list, download, upload, and delete user-sync'd files (ClientSettings.Sav etc.)
+using the existing EpicAuth bearer token — no separate auth flow needed.
+
+Endpoint base: fortnite-public-service-prod11.ol.epicgames.com
+
+Key behavior:
+    GET    /fortnite/api/cloudstorage/user/{accountId}                -> list of files
+    GET    /fortnite/api/cloudstorage/user/{accountId}/{filename}     -> raw bytes
+    PUT    /fortnite/api/cloudstorage/user/{accountId}/{filename}     -> replace
+    DELETE /fortnite/api/cloudstorage/user/{accountId}/{filename}     -> remove
+
+Files the server considers "restricted" (certain per-platform files, UUID
+replay files, etc.) are filtered out by default to avoid accidental
+cross-platform writes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import quote
+
+import requests
+
+from lib.utilities.epic_auth import EpicAuth
+
+logger = logging.getLogger(__name__)
+
+
+CLOUDSTORAGE_BASE = "https://fortnite-public-service-prod11.ol.epicgames.com"
+"""Fortnite cloud storage endpoint root."""
+
+# Files we should never touch — the platform-specific Switch save uses a
+# different container format and trying to read/write it fails server-side.
+RESTRICTED_FILENAMES: set[str] = {"ClientSettingsSwitch.Sav"}
+
+# UUID-pattern files produced by gameplay (replays, temp data); don't expose.
+_UUID_FILE_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_r\d+_a\d+\.sav$",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class CloudFile:
+    unique_filename: str
+    filename: str
+    hash: str
+    hash256: str
+    length: int
+    content_type: str
+    uploaded: str
+    storage_type: str
+    storage_ids: dict
+    do_not_cache: bool
+    raw: dict
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "CloudFile":
+        return cls(
+            unique_filename=d.get("uniqueFilename", ""),
+            filename=d.get("filename", ""),
+            hash=d.get("hash", ""),
+            hash256=d.get("hash256", ""),
+            length=d.get("length", 0),
+            content_type=d.get("contentType", ""),
+            uploaded=d.get("uploaded", ""),
+            storage_type=d.get("storageType", ""),
+            storage_ids=d.get("storageIds", {}),
+            do_not_cache=d.get("doNotCache", False),
+            raw=d,
+        )
+
+
+class CloudStorageError(Exception):
+    """Raised when a cloud-storage call fails."""
+
+
+def is_file_allowed(filename: str) -> bool:
+    """True if `filename` is safe to show/modify via this module."""
+    if filename in RESTRICTED_FILENAMES:
+        return False
+    if _UUID_FILE_RE.match(filename):
+        return False
+    return True
+
+
+class CloudStorage:
+    """Reads/writes the authenticated user's Fortnite cloud storage."""
+
+    def __init__(self, auth: Optional[EpicAuth] = None, base_url: str = CLOUDSTORAGE_BASE) -> None:
+        self.auth = auth or EpicAuth()
+        self.base_url = base_url
+        self._session = requests.Session()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _require_auth(self) -> None:
+        if not self.auth.access_token or not self.auth.account_id:
+            raise CloudStorageError(
+                "Not authenticated with Epic — sign in via FA11y first "
+                "(uses the same session as the Locker/STW features)."
+            )
+        # If the token is expired, try a refresh before giving up.
+        if not self.auth.is_valid and hasattr(self.auth, "refresh_access_token"):
+            try:
+                self.auth.refresh_access_token()
+            except Exception as e:
+                logger.debug("token refresh failed: %s", e)
+
+    def _url(self, filename: str | None = None) -> str:
+        root = f"{self.base_url}/fortnite/api/cloudstorage/user/{self.auth.account_id}"
+        return root if filename is None else f"{root}/{quote(filename, safe='')}"
+
+    def _headers(self, **extra: str) -> dict:
+        h = {"Authorization": f"bearer {self.auth.access_token}"}
+        h.update(extra)
+        return h
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_files(self, include_restricted: bool = False) -> list[CloudFile]:
+        """Return all files in the authenticated user's cloud storage."""
+        self._require_auth()
+        resp = self._session.get(self._url(), headers=self._headers(), timeout=30)
+        if resp.status_code != 200:
+            raise CloudStorageError(
+                f"list failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+
+        data = resp.json()
+        if isinstance(data, list):
+            raw_files = data
+        elif isinstance(data, dict):
+            for key in ("files", "data", "items"):
+                if key in data and isinstance(data[key], list):
+                    raw_files = data[key]
+                    break
+            else:
+                if "uniqueFilename" in data:
+                    raw_files = [data]
+                else:
+                    raise CloudStorageError(f"unexpected list payload: {list(data.keys())}")
+        else:
+            raise CloudStorageError(f"unexpected list payload type: {type(data)!r}")
+
+        files = [CloudFile.from_dict(d) for d in raw_files]
+        if not include_restricted:
+            files = [f for f in files if is_file_allowed(f.unique_filename)]
+        return files
+
+    def find_file(self, filename: str, include_restricted: bool = False) -> CloudFile | None:
+        for f in self.list_files(include_restricted=include_restricted):
+            if f.unique_filename == filename:
+                return f
+        return None
+
+    def download(self, filename: str) -> bytes:
+        """Download a cloud file's raw bytes."""
+        self._require_auth()
+        if not is_file_allowed(filename):
+            raise CloudStorageError(f"file {filename!r} is restricted")
+
+        resp = self._session.get(self._url(filename), headers=self._headers(), timeout=60)
+        if resp.status_code != 200:
+            raise CloudStorageError(
+                f"download {filename} failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+        return resp.content
+
+    def download_to_path(self, filename: str, dest_path: str) -> int:
+        data = self.download(filename)
+        with open(dest_path, "wb") as f:
+            f.write(data)
+        return len(data)
+
+    def upload(self, filename: str, data: bytes) -> None:
+        """Upload bytes as the named cloud file (replaces existing)."""
+        self._require_auth()
+        if not is_file_allowed(filename):
+            raise CloudStorageError(f"file {filename!r} is restricted")
+
+        resp = self._session.put(
+            self._url(filename),
+            headers=self._headers(**{"Content-Type": "application/octet-stream"}),
+            data=data,
+            timeout=60,
+        )
+        if resp.status_code not in (200, 201, 204):
+            raise CloudStorageError(
+                f"upload {filename} failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+
+    def upload_from_path(self, filename: str, src_path: str) -> int:
+        with open(src_path, "rb") as f:
+            data = f.read()
+        self.upload(filename, data)
+        return len(data)
+
+    def delete(self, filename: str) -> None:
+        self._require_auth()
+        if not is_file_allowed(filename):
+            raise CloudStorageError(f"file {filename!r} is restricted")
+
+        resp = self._session.delete(self._url(filename), headers=self._headers(), timeout=30)
+        if resp.status_code not in (200, 204):
+            raise CloudStorageError(
+                f"delete {filename} failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )

--- a/lib/utilities/clientsettings_parser.py
+++ b/lib/utilities/clientsettings_parser.py
@@ -1,0 +1,1042 @@
+"""
+Fortnite ClientSettings.Sav parser and serializer.
+
+Handles the current (UE5-era, Fortnite 27+ / 40+) save format. Supports full
+read and write, so individual properties (including keybinds, sensitivity,
+volumes, etc.) can be modified and the file re-emitted.
+
+Format summary
+--------------
+
+Outer envelope (optional):
+    If the file begins with ASCII "ECFD":
+        [0x00]  "ECFD"                         magic
+        [0x04]  uint32 compressed_flags        (purpose unclear; preserved)
+        [0x08]  uint32 version                 (= 1)
+        [0x0C]  uint32 uncompressed_size
+        [0x10]  zlib-compressed inner stream
+    Otherwise the file IS the inner stream.
+
+Inner stream header:
+    uint32  format_magic                       (0xa2189de9 for 40.20-era)
+    uint32  ue4_package_file_version
+    uint32  ue5_package_file_version
+    uint16  engine_major, uint16 engine_minor, uint16 engine_patch
+    uint32  engine_changelist
+    FString branch                             ("++Fortnite+Release-40.20")
+    int32   post_branch_value                  (custom-version count or -1)
+    <custom-version container + other metadata, variable length>
+    <tagged property body, terminated by Name == "None">
+
+FPropertyTypeName (recursive):
+    FString Name
+    int32   NumParams
+    [FPropertyTypeName; NumParams]
+
+FPropertyTag (UE5 typed-tag format):
+    FString Name
+    if Name == "None": body ends
+    FPropertyTypeName TypeName
+    int32   ValueSize
+    uint8   Flags                              (bitfield, see TagFlag.*)
+    if Flags & HasArrayIndex:       int32 ArrayIndex
+    if Flags & HasPropertyGuid:     16-byte Guid
+    if Flags & HasPropertyExtensions: byte + optional payload
+    <ValueSize bytes of value>
+
+Values: scalar/struct/array/set/map as documented inline.
+
+PartitionContents arrays hold nested save streams using the same inner
+format; they are parsed and serialized recursively.
+
+Round-trip strategy
+-------------------
+
+For write support we don't re-emit the "everything before the property body"
+region from scratch — that region contains a custom-version table whose
+layout varies by engine version and is tedious to implement. Instead we
+split every stream into (header_bytes, property_body) at parse time. On
+serialize we preserve the original header_bytes and only re-emit the body.
+That produces byte-identical output for unmodified files and a
+well-formed file for modified ones, without needing to understand anything
+about the custom-version container.
+
+The `format_magic` is a per-build constant (not a checksum) so it doesn't
+need to be recomputed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import struct
+import sys
+import zlib
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Primitive reader / writer
+# ---------------------------------------------------------------------------
+
+
+class Reader:
+    __slots__ = ("data", "pos")
+
+    def __init__(self, data: bytes, pos: int = 0) -> None:
+        self.data = data
+        self.pos = pos
+
+    def remaining(self) -> int:
+        return len(self.data) - self.pos
+
+    def read(self, n: int) -> bytes:
+        if self.pos + n > len(self.data):
+            raise EOFError(f"need {n} bytes at 0x{self.pos:x}, have {self.remaining()}")
+        v = self.data[self.pos : self.pos + n]
+        self.pos += n
+        return v
+
+    def u8(self) -> int:
+        return self.read(1)[0]
+
+    def i8(self) -> int:
+        return struct.unpack("<b", self.read(1))[0]
+
+    def u16(self) -> int:
+        return struct.unpack("<H", self.read(2))[0]
+
+    def i16(self) -> int:
+        return struct.unpack("<h", self.read(2))[0]
+
+    def u32(self) -> int:
+        return struct.unpack("<I", self.read(4))[0]
+
+    def i32(self) -> int:
+        return struct.unpack("<i", self.read(4))[0]
+
+    def u64(self) -> int:
+        return struct.unpack("<Q", self.read(8))[0]
+
+    def i64(self) -> int:
+        return struct.unpack("<q", self.read(8))[0]
+
+    def f32(self) -> float:
+        return struct.unpack("<f", self.read(4))[0]
+
+    def f64(self) -> float:
+        return struct.unpack("<d", self.read(8))[0]
+
+    def fstring(self) -> str:
+        n = self.i32()
+        if n == 0:
+            return ""
+        if n > 0:
+            raw = self.read(n)
+            return raw[:-1].decode("latin-1", errors="replace")
+        raw = self.read(-n * 2)
+        return raw[:-2].decode("utf-16-le", errors="replace")
+
+    def guid(self) -> bytes:
+        return self.read(16)
+
+
+class Writer:
+    __slots__ = ("buf",)
+
+    def __init__(self) -> None:
+        self.buf = bytearray()
+
+    def write(self, b: bytes) -> None:
+        self.buf.extend(b)
+
+    def u8(self, v: int) -> None:
+        self.buf.append(v & 0xFF)
+
+    def i8(self, v: int) -> None:
+        self.buf.extend(struct.pack("<b", v))
+
+    def u16(self, v: int) -> None:
+        self.buf.extend(struct.pack("<H", v))
+
+    def i16(self, v: int) -> None:
+        self.buf.extend(struct.pack("<h", v))
+
+    def u32(self, v: int) -> None:
+        self.buf.extend(struct.pack("<I", v & 0xFFFFFFFF))
+
+    def i32(self, v: int) -> None:
+        self.buf.extend(struct.pack("<i", v))
+
+    def u64(self, v: int) -> None:
+        self.buf.extend(struct.pack("<Q", v & 0xFFFFFFFFFFFFFFFF))
+
+    def i64(self, v: int) -> None:
+        self.buf.extend(struct.pack("<q", v))
+
+    def f32(self, v: float) -> None:
+        self.buf.extend(struct.pack("<f", v))
+
+    def f64(self, v: float) -> None:
+        self.buf.extend(struct.pack("<d", v))
+
+    def fstring(self, s: str) -> None:
+        if not s:
+            self.i32(0)
+            return
+        # Fortnite always uses ASCII for property names/types. Preserve that
+        # when possible; fall back to UTF-16 for non-ASCII strings.
+        if all(ord(c) < 128 for c in s):
+            data = s.encode("latin-1") + b"\x00"
+            self.i32(len(data))
+            self.buf.extend(data)
+        else:
+            data = s.encode("utf-16-le") + b"\x00\x00"
+            self.i32(-(len(s) + 1))
+            self.buf.extend(data)
+
+
+# ---------------------------------------------------------------------------
+# FPropertyTypeName + FPropertyTag
+# ---------------------------------------------------------------------------
+
+
+class TagFlag:
+    NONE = 0x00
+    HAS_ARRAY_INDEX = 0x01
+    HAS_PROPERTY_GUID = 0x02
+    HAS_PROPERTY_EXTENSIONS = 0x04
+    HAS_BINARY_OR_NATIVE_SERIALIZE = 0x08
+    BOOL_TRUE = 0x10
+    SKIPPED_SERIALIZE = 0x20
+
+
+@dataclass
+class TypeName:
+    name: str
+    params: list["TypeName"] = field(default_factory=list)
+
+    @classmethod
+    def read(cls, r: Reader) -> "TypeName":
+        name = r.fstring()
+        n = r.i32()
+        if n < 0 or n > 64:
+            raise ValueError(f"bogus TypeName param count {n} at 0x{r.pos - 4:x}")
+        params = [cls.read(r) for _ in range(n)]
+        return cls(name=name, params=params)
+
+    def write(self, w: Writer) -> None:
+        w.fstring(self.name)
+        w.i32(len(self.params))
+        for p in self.params:
+            p.write(w)
+
+    @property
+    def struct_name(self) -> str | None:
+        return self.params[0].name if self.params else None
+
+    def to_json(self) -> Any:
+        if not self.params:
+            return self.name
+        return {"name": self.name, "params": [p.to_json() for p in self.params]}
+
+    @classmethod
+    def from_json(cls, obj: Any) -> "TypeName":
+        if isinstance(obj, str):
+            return cls(name=obj)
+        return cls(
+            name=obj["name"],
+            params=[cls.from_json(p) for p in obj.get("params", [])],
+        )
+
+
+@dataclass
+class PropertyTag:
+    name: str
+    type_name: TypeName
+    flags: int
+    array_index: int = 0
+    property_guid: bytes | None = None
+    extension_payload: bytes = b""
+    bool_value: bool = False
+
+    @classmethod
+    def read(cls, r: Reader) -> "PropertyTag | None":
+        name = r.fstring()
+        if name == "None":
+            return None
+        tn = TypeName.read(r)
+        size = r.i32()
+        flags = r.u8()
+
+        array_index = 0
+        if flags & TagFlag.HAS_ARRAY_INDEX:
+            array_index = r.i32()
+
+        guid: bytes | None = None
+        if flags & TagFlag.HAS_PROPERTY_GUID:
+            guid = r.guid()
+
+        ext_payload = b""
+        if flags & TagFlag.HAS_PROPERTY_EXTENSIONS:
+            ext_flags = r.u8()
+            if ext_flags & 0x01:
+                ext_payload = bytes([ext_flags, r.u8()])
+            else:
+                ext_payload = bytes([ext_flags])
+
+        bool_value = bool(flags & TagFlag.BOOL_TRUE)
+
+        tag = cls(
+            name=name,
+            type_name=tn,
+            flags=flags,
+            array_index=array_index,
+            property_guid=guid,
+            extension_payload=ext_payload,
+            bool_value=bool_value,
+        )
+        tag._value_size = size  # only used during parsing
+        return tag
+
+    def write_name_and_type(self, w: Writer) -> int:
+        """Write Name + TypeName. Returns offset where Size int32 will go."""
+        w.fstring(self.name)
+        self.type_name.write(w)
+        size_offset = len(w.buf)
+        w.i32(0)  # placeholder; patched by caller once value is written
+        return size_offset
+
+    def write_trailing_flags(self, w: Writer) -> None:
+        """Write Flags + (optional) ArrayIndex/Guid/Extensions."""
+        w.u8(self.flags & 0xFF)
+        if self.flags & TagFlag.HAS_ARRAY_INDEX:
+            w.i32(self.array_index)
+        if self.flags & TagFlag.HAS_PROPERTY_GUID:
+            if self.property_guid is None:
+                raise ValueError("HAS_PROPERTY_GUID set but no guid")
+            w.write(self.property_guid)
+        if self.flags & TagFlag.HAS_PROPERTY_EXTENSIONS:
+            w.write(self.extension_payload)
+
+
+# ---------------------------------------------------------------------------
+# Value objects
+# ---------------------------------------------------------------------------
+
+
+HARDCODED_STRUCTS = {"Vector2D", "DateTime", "Guid", "GameplayTagContainer"}
+
+
+def _read_hardcoded_struct(r: Reader, struct_name: str) -> dict:
+    if struct_name == "Vector2D":
+        return {"__struct__": "Vector2D", "X": r.f64(), "Y": r.f64()}
+    if struct_name == "DateTime":
+        return {"__struct__": "DateTime", "ticks": r.i64()}
+    if struct_name == "Guid":
+        return {"__struct__": "Guid", "guid": r.guid().hex()}
+    if struct_name == "GameplayTagContainer":
+        # int32 NumTags + FString*NumTags (native binary serialize)
+        n = r.i32()
+        if n < 0 or n > 10000:
+            raise ValueError(f"absurd GameplayTagContainer count {n}")
+        return {"__struct__": "GameplayTagContainer", "Tags": [r.fstring() for _ in range(n)]}
+    raise ValueError(f"unknown hardcoded struct: {struct_name}")
+
+
+def _write_hardcoded_struct(w: Writer, struct_name: str, value: dict) -> None:
+    if struct_name == "Vector2D":
+        w.f64(float(value["X"])); w.f64(float(value["Y"]))
+        return
+    if struct_name == "DateTime":
+        w.i64(int(value["ticks"]))
+        return
+    if struct_name == "Guid":
+        raw = value["guid"]
+        w.write(bytes.fromhex(raw) if isinstance(raw, str) else raw)
+        return
+    if struct_name == "GameplayTagContainer":
+        tags = value["Tags"]
+        w.i32(len(tags))
+        for t in tags:
+            w.fstring(t)
+        return
+    raise ValueError(f"unknown hardcoded struct: {struct_name}")
+
+
+@dataclass
+class Property:
+    """One top-level (or child) property: tag + value."""
+    tag: PropertyTag
+    value: Any  # python-native for scalars; Property lists for struct/array
+
+
+@dataclass
+class NestedSave:
+    """PartitionContents byte arrays that are themselves save streams."""
+    header_bytes: bytes
+    properties: list[Property]
+    trailing: bytes = b""  # bytes after the "None" terminator (usually small padding)
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+FORMAT_MAGIC_40_20 = 0xA2189DE9
+
+
+def _read_scalar(r: Reader, tn: TypeName) -> Any:
+    t = tn.name
+    if t == "IntProperty":
+        return r.i32()
+    if t == "UInt32Property":
+        return r.u32()
+    if t == "Int64Property":
+        return r.i64()
+    if t == "UInt64Property":
+        return r.u64()
+    if t == "Int16Property":
+        return r.i16()
+    if t == "UInt16Property":
+        return r.u16()
+    if t == "Int8Property":
+        return r.i8()
+    if t == "ByteProperty":
+        # With an enum param the value is an FString; without it's a raw byte.
+        if tn.params:
+            return r.fstring()
+        return r.u8()
+    if t == "EnumProperty":
+        return r.fstring()
+    if t == "FloatProperty":
+        return r.f32()
+    if t == "DoubleProperty":
+        return r.f64()
+    if t == "BoolProperty":
+        # Top-level BoolProperty lives in the tag's BOOL_TRUE flag (no value
+        # bytes). Inside a Map/Set/Array, BoolProperty is a single byte.
+        return bool(r.u8())
+    if t == "NameProperty":
+        return r.fstring()
+    if t == "StrProperty":
+        return r.fstring()
+    if t == "TextProperty":
+        return _read_text(r)
+    if t == "ObjectProperty":
+        return r.fstring()
+    if t == "SoftObjectProperty":
+        return r.fstring()
+    if t == "StructProperty":
+        return _read_struct(r, tn)
+    raise ValueError(f"unsupported scalar type {t}")
+
+
+def _read_text(r: Reader) -> dict:
+    flags = r.i32()
+    history = r.u8()
+    if history == 0xFF:
+        return {"history": "None", "flags": flags}
+    if history != 0:
+        return {"history": f"unsupported={history}", "flags": flags}
+    return {
+        "history": "Base",
+        "flags": flags,
+        "namespace": r.fstring(),
+        "key": r.fstring(),
+        "source": r.fstring(),
+    }
+
+
+def _read_struct(r: Reader, tn: TypeName) -> Any:
+    struct_name = tn.struct_name
+    if struct_name in HARDCODED_STRUCTS:
+        return _read_hardcoded_struct(r, struct_name)
+    # Generic: a run of tagged properties ending in "None"
+    props = _read_tagged_body(r, context=f"struct[{struct_name}]")
+    return {"__struct__": struct_name, "__props__": props}
+
+
+def _read_array(r: Reader, tn: TypeName) -> Any:
+    n = r.i32()
+    inner = tn.params[0] if tn.params else TypeName(name="")
+
+    if inner.name == "ByteProperty":
+        payload = r.read(n)
+        nested = _try_parse_nested_save(payload)
+        if nested is not None:
+            return {"__byte_array__": True, "nested_save": nested}
+        return {"__byte_array__": True, "bytes": payload}
+
+    if inner.name == "StructProperty":
+        items = []
+        for _ in range(n):
+            items.append(_read_struct(r, inner))
+        return {"__array__": True, "inner_type": inner, "items": items}
+
+    items = []
+    for _ in range(n):
+        if inner.name == "BoolProperty":
+            items.append(bool(r.u8()))
+        else:
+            items.append(_read_scalar(r, inner))
+    return {"__array__": True, "inner_type": inner, "items": items}
+
+
+def _read_tagged_body(r: Reader, context: str = "") -> list[Property]:
+    out: list[Property] = []
+    while True:
+        tag_offset = r.pos
+        try:
+            tag = PropertyTag.read(r)
+        except Exception as e:
+            raise ValueError(
+                f"[{context}] tag-read failed at 0x{tag_offset:x}: {e}. "
+                f"Last successful props: {[p.tag.name for p in out[-5:]]}"
+            ) from e
+        if tag is None:
+            return out
+
+        value_bytes = r.read(getattr(tag, "_value_size"))
+        if tag.type_name.name == "BoolProperty":
+            out.append(Property(tag=tag, value=tag.bool_value))
+            continue
+
+        sub = Reader(value_bytes)
+        if tag.type_name.name == "ArrayProperty":
+            value = _read_array(sub, tag.type_name)
+        elif tag.type_name.name == "SetProperty":
+            sub.i32()  # ElementsToRemove
+            inner = tag.type_name.params[0] if tag.type_name.params else TypeName(name="")
+            k = sub.i32()
+            value = {
+                "__set__": True,
+                "inner_type": inner,
+                "items": [_read_scalar(sub, inner) for _ in range(k)],
+            }
+        elif tag.type_name.name == "MapProperty":
+            sub.i32()  # NumKeysToRemove
+            kn = tag.type_name.params[0] if len(tag.type_name.params) > 0 else TypeName("")
+            vn = tag.type_name.params[1] if len(tag.type_name.params) > 1 else TypeName("")
+            k = sub.i32()
+            entries: list[dict] = []
+            for i in range(k):
+                try:
+                    key_val = _read_scalar(sub, kn)
+                    val_val = _read_scalar(sub, vn)
+                    entries.append({"key": key_val, "value": val_val})
+                except Exception as e:
+                    raise ValueError(
+                        f"Map '{tag.name}' entry {i}/{k} failed "
+                        f"(key_type={kn.to_json()}, value_type={vn.to_json()}): {e}. "
+                        f"Value sub-reader at 0x{sub.pos:x}, peek: {sub.data[sub.pos:sub.pos+32].hex()}"
+                    ) from e
+            value = {
+                "__map__": True,
+                "key_type": kn,
+                "value_type": vn,
+                "entries": entries,
+            }
+        elif tag.type_name.name == "StructProperty":
+            value = _read_struct(sub, tag.type_name)
+        else:
+            value = _read_scalar(sub, tag.type_name)
+
+        if sub.remaining() > 0:
+            # Keep unknown trailing bytes so we can round-trip them.
+            value = {"__value__": value, "__trailing__": sub.data[sub.pos:]}
+        out.append(Property(tag=tag, value=value))
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+def _write_scalar(w: Writer, tn: TypeName, value: Any) -> None:
+    t = tn.name
+    if t == "IntProperty":
+        w.i32(int(value))
+    elif t == "UInt32Property":
+        w.u32(int(value))
+    elif t == "Int64Property":
+        w.i64(int(value))
+    elif t == "UInt64Property":
+        w.u64(int(value))
+    elif t == "Int16Property":
+        w.i16(int(value))
+    elif t == "UInt16Property":
+        w.u16(int(value))
+    elif t == "Int8Property":
+        w.i8(int(value))
+    elif t == "ByteProperty":
+        if tn.params:
+            w.fstring(str(value))
+        else:
+            w.u8(int(value))
+    elif t == "EnumProperty":
+        w.fstring(str(value))
+    elif t == "BoolProperty":
+        # Inline bool inside Map/Set/Array — single byte.
+        w.u8(1 if value else 0)
+    elif t == "FloatProperty":
+        w.f32(float(value))
+    elif t == "DoubleProperty":
+        w.f64(float(value))
+    elif t == "NameProperty" or t == "StrProperty" or t == "ObjectProperty" or t == "SoftObjectProperty":
+        w.fstring(str(value))
+    elif t == "TextProperty":
+        _write_text(w, value)
+    elif t == "StructProperty":
+        _write_struct(w, tn, value)
+    else:
+        raise ValueError(f"unsupported scalar type for write: {t}")
+
+
+def _write_text(w: Writer, value: dict) -> None:
+    w.i32(int(value.get("flags", 0)))
+    history = value.get("history", "None")
+    if history == "None":
+        w.u8(0xFF)
+        return
+    if history != "Base":
+        raise ValueError(f"unsupported text history for write: {history}")
+    w.u8(0)
+    w.fstring(value.get("namespace", ""))
+    w.fstring(value.get("key", ""))
+    w.fstring(value.get("source", ""))
+
+
+def _write_struct(w: Writer, tn: TypeName, value: Any) -> None:
+    struct_name = tn.struct_name
+    if struct_name in HARDCODED_STRUCTS:
+        _write_hardcoded_struct(w, struct_name, value)
+        return
+    props = value["__props__"]
+    _write_tagged_body(w, props)
+
+
+def _write_array(w: Writer, tn: TypeName, value: Any) -> None:
+    if value.get("__byte_array__"):
+        if "nested_save" in value:
+            nested_bytes = _serialize_save_stream(value["nested_save"])
+            w.i32(len(nested_bytes))
+            w.write(nested_bytes)
+        else:
+            raw = value["bytes"]
+            w.i32(len(raw))
+            w.write(raw)
+        return
+
+    inner = value.get("inner_type") or (tn.params[0] if tn.params else TypeName(""))
+    if isinstance(inner, dict) or isinstance(inner, str):
+        inner = TypeName.from_json(inner)
+    items = value["items"]
+    w.i32(len(items))
+    if inner.name == "StructProperty":
+        for it in items:
+            _write_struct(w, inner, it)
+    elif inner.name == "BoolProperty":
+        for it in items:
+            w.u8(1 if it else 0)
+    else:
+        for it in items:
+            _write_scalar(w, inner, it)
+
+
+def _write_tagged_body(w: Writer, props: list[Property]) -> None:
+    for p in props:
+        _write_property(w, p)
+    # terminator
+    w.fstring("None")
+
+
+def _write_property(w: Writer, p: Property) -> None:
+    tag = p.tag
+
+    # BoolProperty has no value bytes; bool value lives in the flags.
+    if tag.type_name.name == "BoolProperty":
+        new_flags = tag.flags & ~TagFlag.BOOL_TRUE
+        if bool(p.value):
+            new_flags |= TagFlag.BOOL_TRUE
+        tag.flags = new_flags
+        size_offset = tag.write_name_and_type(w)
+        tag.write_trailing_flags(w)
+        # Patch size = 0
+        struct.pack_into("<i", w.buf, size_offset, 0)
+        return
+
+    size_offset = tag.write_name_and_type(w)
+    tag.write_trailing_flags(w)
+
+    value_start = len(w.buf)
+
+    value = p.value
+    trailing = b""
+    if isinstance(value, dict) and "__trailing__" in value:
+        trailing = value["__trailing__"]
+        value = value["__value__"]
+
+    if tag.type_name.name == "ArrayProperty":
+        _write_array(w, tag.type_name, value)
+    elif tag.type_name.name == "SetProperty":
+        inner = value.get("inner_type") or (tag.type_name.params[0] if tag.type_name.params else TypeName(""))
+        if isinstance(inner, dict) or isinstance(inner, str):
+            inner = TypeName.from_json(inner)
+        w.i32(0)  # ElementsToRemove
+        items = value["items"]
+        w.i32(len(items))
+        for it in items:
+            _write_scalar(w, inner, it)
+    elif tag.type_name.name == "MapProperty":
+        kn = value.get("key_type") or (tag.type_name.params[0] if tag.type_name.params else TypeName(""))
+        vn = value.get("value_type") or (tag.type_name.params[1] if len(tag.type_name.params) > 1 else TypeName(""))
+        if isinstance(kn, (dict, str)):
+            kn = TypeName.from_json(kn)
+        if isinstance(vn, (dict, str)):
+            vn = TypeName.from_json(vn)
+        w.i32(0)  # NumKeysToRemove
+        entries = value["entries"]
+        w.i32(len(entries))
+        for e in entries:
+            _write_scalar(w, kn, e["key"])
+            _write_scalar(w, vn, e["value"])
+    elif tag.type_name.name == "StructProperty":
+        _write_struct(w, tag.type_name, value)
+    else:
+        _write_scalar(w, tag.type_name, value)
+
+    if trailing:
+        w.write(trailing)
+
+    value_end = len(w.buf)
+    struct.pack_into("<i", w.buf, size_offset, value_end - value_start)
+
+
+# ---------------------------------------------------------------------------
+# Save stream (header + body)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SaveStream:
+    """A full parsed save stream = opaque header + parsed property body."""
+    header_bytes: bytes                      # everything before first property tag
+    properties: list[Property]
+    trailing: bytes                          # bytes after the "None" terminator
+
+
+def _looks_like_property_tag(data: bytes, pos: int) -> bool:
+    """Does `pos` point at a plausible FPropertyTag or bare 'None' terminator?"""
+    if pos + 8 > len(data):
+        return False
+    try:
+        n = struct.unpack_from("<i", data, pos)[0]
+    except struct.error:
+        return False
+    if not (2 <= n <= 200):
+        return False
+    if pos + 4 + n > len(data):
+        return False
+    name_bytes = data[pos + 4 : pos + 4 + n]
+    if name_bytes[-1] != 0:
+        return False
+    name = name_bytes[:-1]
+    if not all(0x20 <= b < 0x7F for b in name):
+        return False
+    if not (chr(name[0]).isalpha() or name[0] == ord("_")):
+        return False
+    if name == b"None":
+        return True
+    type_pos = pos + 4 + n
+    if type_pos + 8 > len(data):
+        return False
+    tn = struct.unpack_from("<i", data, type_pos)[0]
+    if not (6 <= tn <= 60):
+        return False
+    if type_pos + 4 + tn > len(data):
+        return False
+    type_bytes = data[type_pos + 4 : type_pos + 4 + tn]
+    if type_bytes[-1] != 0:
+        return False
+    type_str = type_bytes[:-1].decode("latin-1", errors="replace")
+    return type_str.endswith("Property")
+
+
+def _locate_body_start(data: bytes, scan_from: int) -> int:
+    limit = min(len(data) - 9, scan_from + 128 * 1024)
+    for off in range(scan_from, limit + 1):
+        if _looks_like_property_tag(data, off):
+            return off
+    raise ValueError(f"could not locate property body after 0x{scan_from:x}")
+
+
+def _parse_save_stream(stream: bytes) -> SaveStream:
+    r = Reader(stream)
+
+    # Validate header is the new (UE5-era) format. We don't care about the
+    # specific values — we just need to know where the property body starts.
+    r.u32()  # format_magic
+    r.u32()  # ue4
+    r.u32()  # ue5
+    r.u16(); r.u16(); r.u16(); r.u32()  # engine version + changelist
+
+    branch = r.fstring()
+    r.i32()  # post_branch_value
+
+    if not branch.startswith("++Fortnite+Release-"):
+        raise ValueError(f"not a Fortnite save stream (branch={branch!r})")
+
+    # Confirm UE5-era: engine major >= 5. We need the UE5 flag byte layout.
+    ue5_major = struct.unpack_from("<H", stream, 12)[0]
+    if ue5_major < 5:
+        raise ValueError(
+            f"old UE4 save format (engine {ue5_major}.x) not supported for write "
+            "— this parser only handles UE5-era (Fortnite 27+) saves"
+        )
+
+    body_start = _locate_body_start(stream, r.pos)
+    header = stream[:body_start]
+
+    r.pos = body_start
+    props = _read_tagged_body(r)
+
+    trailing = stream[r.pos:]
+    return SaveStream(header_bytes=header, properties=props, trailing=trailing)
+
+
+def _serialize_save_stream(stream: SaveStream) -> bytes:
+    w = Writer()
+    w.write(stream.header_bytes)
+    _write_tagged_body(w, stream.properties)
+    w.write(stream.trailing)
+    return bytes(w.buf)
+
+
+def _try_parse_nested_save(blob: bytes) -> SaveStream | None:
+    """PartitionContents byte arrays are themselves save streams."""
+    if len(blob) < 32:
+        return None
+    try:
+        ue4 = struct.unpack_from("<I", blob, 4)[0]
+        ue5 = struct.unpack_from("<I", blob, 8)[0]
+        if not (400 <= ue4 <= 800):
+            return None
+        if not (800 <= ue5 <= 3000):
+            return None
+        branch_len = struct.unpack_from("<i", blob, 22)[0]
+        if not (4 <= branch_len <= 200):
+            return None
+        branch = blob[26 : 26 + branch_len - 1]
+        if not branch.startswith(b"++"):
+            return None
+    except struct.error:
+        return None
+
+    try:
+        return _parse_save_stream(blob)
+    except Exception as e:
+        logger.debug("nested-save parse failed: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# ECFD outer envelope
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClientSettingsFile:
+    """Full parsed ClientSettings.Sav, preserving enough to round-trip."""
+    stream: SaveStream
+    ecfd_compressed_flags: int | None = None  # bytes 0x04-0x07 of ECFD header
+    ecfd_version: int | None = None           # bytes 0x08-0x0b
+    was_compressed: bool = False
+
+    @property
+    def properties(self) -> list[Property]:
+        return self.stream.properties
+
+
+def _has_ecfd_wrapper(data: bytes) -> bool:
+    return data[:4] == b"ECFD"
+
+
+def parse_file(data: bytes) -> ClientSettingsFile:
+    if _has_ecfd_wrapper(data):
+        flags = struct.unpack_from("<I", data, 4)[0]
+        version = struct.unpack_from("<I", data, 8)[0]
+        # data[12:16] is uncompressed_size; we recompute on serialize
+        raw = zlib.decompress(data[0x10:])
+        stream = _parse_save_stream(raw)
+        return ClientSettingsFile(
+            stream=stream,
+            ecfd_compressed_flags=flags,
+            ecfd_version=version,
+            was_compressed=True,
+        )
+    stream = _parse_save_stream(data)
+    return ClientSettingsFile(stream=stream, was_compressed=False)
+
+
+def serialize_file(f: ClientSettingsFile) -> bytes:
+    body = _serialize_save_stream(f.stream)
+    if not f.was_compressed:
+        return body
+    # zlib-compress with max compression (matches Fortnite's 0x78 0xDA output).
+    compressed = zlib.compress(body, level=9)
+    w = Writer()
+    w.write(b"ECFD")
+    w.u32(f.ecfd_compressed_flags if f.ecfd_compressed_flags is not None else 0)
+    w.u32(f.ecfd_version if f.ecfd_version is not None else 1)
+    w.u32(len(body))
+    w.write(compressed)
+    return bytes(w.buf)
+
+
+# ---------------------------------------------------------------------------
+# Convenience accessors
+# ---------------------------------------------------------------------------
+
+
+def find_property(props: list[Property], name: str) -> Property | None:
+    for p in props:
+        if p.tag.name == name:
+            return p
+    return None
+
+
+def get_value(props: list[Property], name: str) -> Any:
+    p = find_property(props, name)
+    return p.value if p is not None else None
+
+
+def set_value(props: list[Property], name: str, new_value: Any) -> bool:
+    """Replace the scalar value of a named property. Returns True if it was found."""
+    p = find_property(props, name)
+    if p is None:
+        return False
+    if isinstance(p.value, dict) and "__trailing__" in p.value:
+        p.value = {"__value__": new_value, "__trailing__": p.value["__trailing__"]}
+    else:
+        p.value = new_value
+    return True
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers (human-readable dump)
+# ---------------------------------------------------------------------------
+
+
+def _value_to_json(value: Any) -> Any:
+    if isinstance(value, Property):
+        return {"name": value.tag.name, "type": value.tag.type_name.to_json(), "value": _value_to_json(value.value)}
+    if isinstance(value, list):
+        return [_value_to_json(v) for v in value]
+    if isinstance(value, dict):
+        if value.get("__byte_array__"):
+            if "nested_save" in value:
+                return {"nested_save": _stream_to_json(value["nested_save"])}
+            return {"bytes_hex": value["bytes"].hex(), "bytes_len": len(value["bytes"])}
+        if value.get("__array__"):
+            return {
+                "inner_type": value["inner_type"].to_json() if isinstance(value["inner_type"], TypeName) else value["inner_type"],
+                "items": [_value_to_json(i) for i in value["items"]],
+            }
+        if value.get("__set__"):
+            return {
+                "inner_type": value["inner_type"].to_json() if isinstance(value["inner_type"], TypeName) else value["inner_type"],
+                "items": [_value_to_json(i) for i in value["items"]],
+            }
+        if value.get("__map__"):
+            return {
+                "key_type": value["key_type"].to_json() if isinstance(value["key_type"], TypeName) else value["key_type"],
+                "value_type": value["value_type"].to_json() if isinstance(value["value_type"], TypeName) else value["value_type"],
+                "entries": [{"key": _value_to_json(e["key"]), "value": _value_to_json(e["value"])} for e in value["entries"]],
+            }
+        if "__struct__" in value:
+            struct_name = value["__struct__"]
+            if struct_name in HARDCODED_STRUCTS:
+                out = {"__struct__": struct_name}
+                out.update({k: v for k, v in value.items() if k != "__struct__"})
+                return out
+            return {
+                "__struct__": struct_name,
+                "props": {p.tag.name: _value_to_json(p.value) for p in value["__props__"]},
+            }
+        if "__value__" in value:
+            return {"__value__": _value_to_json(value["__value__"]), "__trailing__": value["__trailing__"].hex()}
+        return value
+    if isinstance(value, bytes):
+        return value.hex()
+    return value
+
+
+def _stream_to_json(stream: SaveStream) -> dict:
+    return {
+        "header_size": len(stream.header_bytes),
+        "trailing_size": len(stream.trailing),
+        "properties": {p.tag.name: _value_to_json(p.value) for p in stream.properties},
+    }
+
+
+def to_json(f: ClientSettingsFile) -> dict:
+    return {
+        "was_compressed": f.was_compressed,
+        **_stream_to_json(f.stream),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Parse/serialize Fortnite ClientSettings.Sav")
+    ap.add_argument("input", help="Path to ClientSettings.Sav")
+    ap.add_argument("-o", "--output", help="Output path (JSON unless --rewrite)")
+    ap.add_argument("--rewrite", action="store_true",
+                    help="Parse then re-serialize as .Sav to verify round-trip.")
+    args = ap.parse_args(argv)
+
+    with open(args.input, "rb") as f:
+        data = f.read()
+
+    parsed = parse_file(data)
+
+    if args.rewrite:
+        re = serialize_file(parsed)
+        dst = args.output or (args.input + ".round-trip.sav")
+        with open(dst, "wb") as f:
+            f.write(re)
+        same = re == data
+        print(f"Wrote {len(re)} bytes to {dst}. byte-identical={same}", file=sys.stderr)
+        if not same:
+            # Show where they diverge
+            for i in range(min(len(re), len(data))):
+                if re[i] != data[i]:
+                    print(f"  first diff at offset 0x{i:x}: orig={data[i]:#x} vs new={re[i]:#x}", file=sys.stderr)
+                    break
+            if len(re) != len(data):
+                print(f"  length diff: orig={len(data)} new={len(re)}", file=sys.stderr)
+        return 0 if same else 1
+
+    doc = to_json(parsed)
+    text = json.dumps(doc, indent=2, default=str)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(text)
+    else:
+        sys.stdout.write(text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    raise SystemExit(main())

--- a/lib/utilities/clientsettings_sync.py
+++ b/lib/utilities/clientsettings_sync.py
@@ -1,0 +1,407 @@
+"""
+High-level ClientSettings.Sav manager for FA11y.
+
+Ties together the parser/serializer (:mod:`clientsettings_parser`) and the
+cloud storage client (:mod:`clientsettings_cloud`) to provide a small
+practical API for the features FA11y needs:
+
+    - locate local ClientSettings.Sav files (the in-use copy in
+      Saved/Config/ as well as per-slot Cloud copies)
+    - fetch the cloud copy from the authenticated Epic account
+    - compare local vs cloud (a short structured diff)
+    - push local -> cloud (so a device's settings become the canonical copy)
+    - pull cloud -> local (so this device picks up settings from another)
+    - query and mutate keybinds via action name, then re-serialize + upload
+
+The file is locked while Fortnite is running, so local writes are gated on
+the game being closed. The cloud sync itself is unaffected by the game.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from lib.utilities.clientsettings_cloud import CloudStorage, CloudStorageError
+from lib.utilities.clientsettings_parser import (
+    ClientSettingsFile,
+    Property,
+    TypeName,
+    find_property,
+    get_value,
+    parse_file,
+    serialize_file,
+    set_value,
+)
+from lib.utilities.epic_auth import EpicAuth
+
+logger = logging.getLogger(__name__)
+
+
+CLIENT_SETTINGS_FILENAME = "ClientSettings.Sav"
+
+
+# ---------------------------------------------------------------------------
+# Local file discovery
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LocalClientSettings:
+    """Where ClientSettings.Sav lives on this machine."""
+    config_path: Path                 # %LOCALAPPDATA%/FortniteGame/Saved/Config/ClientSettings.Sav
+    cloud_slot_paths: list[Path] = field(default_factory=list)  # .../Cloud/<slotid>/ClientSettings.Sav
+
+    @property
+    def primary(self) -> Path:
+        """The file to read/write. Prefers Config/, falls back to a Cloud slot."""
+        if self.config_path.exists():
+            return self.config_path
+        for p in self.cloud_slot_paths:
+            if p.exists():
+                return p
+        return self.config_path  # may not exist
+
+
+def locate_local() -> LocalClientSettings:
+    """Find the local Fortnite save folders. Doesn't require the game to run."""
+    localappdata = os.environ.get("LOCALAPPDATA")
+    if not localappdata:
+        raise RuntimeError("LOCALAPPDATA env var not set")
+
+    base = Path(localappdata) / "FortniteGame" / "Saved"
+    config_file = base / "Config" / CLIENT_SETTINGS_FILENAME
+
+    cloud_files: list[Path] = []
+    cloud_dir = base / "Cloud"
+    if cloud_dir.is_dir():
+        for slot in sorted(cloud_dir.iterdir()):
+            if slot.is_dir():
+                f = slot / CLIENT_SETTINGS_FILENAME
+                if f.exists():
+                    cloud_files.append(f)
+
+    return LocalClientSettings(config_path=config_file, cloud_slot_paths=cloud_files)
+
+
+def is_fortnite_running() -> bool:
+    """Cheap best-effort check — looks for FortniteClient-Win64-Shipping.exe."""
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return False
+    for p in psutil.process_iter(["name"]):
+        try:
+            name = p.info.get("name") or ""
+            if name.lower().startswith("fortniteclient-win64"):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SettingsDiff:
+    only_local: list[str]
+    only_cloud: list[str]
+    different: list[dict]    # [{name, local, cloud}]
+
+    def is_empty(self) -> bool:
+        return not (self.only_local or self.only_cloud or self.different)
+
+    def summary(self) -> str:
+        lines = []
+        if self.only_local:
+            lines.append(f"only local: {len(self.only_local)}")
+        if self.only_cloud:
+            lines.append(f"only cloud: {len(self.only_cloud)}")
+        if self.different:
+            lines.append(f"different:  {len(self.different)}")
+        if not lines:
+            return "local and cloud are identical"
+        return " / ".join(lines)
+
+
+def _simplify(value: Any) -> Any:
+    """Collapse parser-internal dict shapes into something diff-friendly."""
+    if isinstance(value, dict):
+        if "__value__" in value:
+            return _simplify(value["__value__"])
+        if value.get("__byte_array__"):
+            if "nested_save" in value:
+                n = value["nested_save"]
+                return {"__nested_save__": {p.tag.name: _simplify(p.value) for p in n.properties}}
+            return {"__bytes_len__": len(value["bytes"])}
+        if value.get("__array__"):
+            return [_simplify(i) for i in value["items"]]
+        if value.get("__set__"):
+            return [_simplify(i) for i in value["items"]]
+        if value.get("__map__"):
+            return [{"key": _simplify(e["key"]), "value": _simplify(e["value"])} for e in value["entries"]]
+        if "__struct__" in value:
+            sname = value["__struct__"]
+            if sname in ("Vector2D", "DateTime", "Guid", "GameplayTagContainer"):
+                return {k: v for k, v in value.items() if k != "__struct__"} | {"__struct__": sname}
+            return {p.tag.name: _simplify(p.value) for p in value.get("__props__", [])}
+        return value
+    if isinstance(value, bytes):
+        return value.hex()
+    return value
+
+
+def diff_settings(a: ClientSettingsFile, b: ClientSettingsFile) -> SettingsDiff:
+    """Return a structural diff between two parsed save files."""
+    a_map = {p.tag.name: _simplify(p.value) for p in a.properties}
+    b_map = {p.tag.name: _simplify(p.value) for p in b.properties}
+
+    only_a = sorted(k for k in a_map if k not in b_map)
+    only_b = sorted(k for k in b_map if k not in a_map)
+    diffs = []
+    for k in sorted(a_map.keys() & b_map.keys()):
+        if a_map[k] != b_map[k]:
+            diffs.append({"name": k, "local": a_map[k], "cloud": b_map[k]})
+    return SettingsDiff(only_local=only_a, only_cloud=only_b, different=diffs)
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+
+class ClientSettingsManager:
+    """Orchestrates local <-> cloud operations for ClientSettings.Sav."""
+
+    def __init__(
+        self,
+        auth: Optional[EpicAuth] = None,
+        local: Optional[LocalClientSettings] = None,
+        cloud: Optional[CloudStorage] = None,
+    ) -> None:
+        self.auth = auth or EpicAuth()
+        self.local = local or locate_local()
+        self.cloud = cloud or CloudStorage(self.auth)
+
+    # ------------------------------ local ----------------------------------
+
+    def read_local(self) -> ClientSettingsFile:
+        path = self.local.primary
+        if not path.exists():
+            raise FileNotFoundError(f"no local ClientSettings.Sav at {path}")
+        return parse_file(path.read_bytes())
+
+    def write_local(self, parsed: ClientSettingsFile, *, require_game_closed: bool = True) -> Path:
+        """Serialize + write back to the primary local path. Makes a .bak first."""
+        if require_game_closed and is_fortnite_running():
+            raise RuntimeError(
+                "Fortnite is running and holds a lock on ClientSettings.Sav — close it first."
+            )
+        path = self.local.primary
+        data = serialize_file(parsed)
+        if path.exists():
+            backup = path.with_suffix(path.suffix + f".bak-{int(time.time())}")
+            shutil.copy2(path, backup)
+            logger.info("backed up existing save to %s", backup)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    # ------------------------------ cloud ----------------------------------
+
+    def read_cloud(self, filename: str = CLIENT_SETTINGS_FILENAME) -> ClientSettingsFile:
+        data = self.cloud.download(filename)
+        return parse_file(data)
+
+    def push_to_cloud(self, *, source: Optional[Path] = None, filename: str = CLIENT_SETTINGS_FILENAME) -> int:
+        """Upload the local file (or a different path) to cloud verbatim."""
+        path = Path(source) if source else self.local.primary
+        if not path.exists():
+            raise FileNotFoundError(f"nothing to upload at {path}")
+        # Validate: parse it first so we don't upload a corrupt file.
+        try:
+            parse_file(path.read_bytes())
+        except Exception as e:
+            raise CloudStorageError(f"refused to upload — file doesn't parse: {e}") from e
+        return self.cloud.upload_from_path(filename, str(path))
+
+    def pull_from_cloud(self, *, filename: str = CLIENT_SETTINGS_FILENAME,
+                        dest: Optional[Path] = None, require_game_closed: bool = True) -> Path:
+        """Download cloud copy and write it over the local primary file."""
+        if require_game_closed and is_fortnite_running():
+            raise RuntimeError(
+                "Fortnite is running and holds a lock on ClientSettings.Sav — close it first."
+            )
+        target = Path(dest) if dest else self.local.primary
+        data = self.cloud.download(filename)
+        # Validate before writing.
+        parse_file(data)
+        if target.exists():
+            backup = target.with_suffix(target.suffix + f".bak-{int(time.time())}")
+            shutil.copy2(target, backup)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        return target
+
+    def compare(self) -> SettingsDiff:
+        """Read local + cloud and return a structural diff."""
+        local = self.read_local()
+        cloud = self.read_cloud()
+        return diff_settings(local, cloud)
+
+    # ------------------------------ accessors -------------------------------
+
+    @staticmethod
+    def get(parsed: ClientSettingsFile, name: str) -> Any:
+        return get_value(parsed.properties, name)
+
+    @staticmethod
+    def set(parsed: ClientSettingsFile, name: str, value: Any) -> bool:
+        return set_value(parsed.properties, name, value)
+
+    # ------------------------------ keybinds --------------------------------
+
+    @staticmethod
+    def _iter_bindings(parsed: ClientSettingsFile, sub_game: str | None = None) -> list[dict]:
+        """Return a flat list of binding dicts from UserBindingsPerSubGame.
+
+        If `sub_game` is provided (e.g. "ESubGame::Athena"), only return that
+        group's bindings. Each dict is the parsed StructProperty value for one
+        FortActionKeyMapping-like entry and can be mutated in place (then
+        re-serialized).
+        """
+        prop = find_property(parsed.properties, "UserBindingsPerSubGame")
+        if prop is None:
+            return []
+
+        # Value is a MapProperty wrapper
+        container = prop.value
+        if isinstance(container, dict) and container.get("__map__"):
+            entries = container["entries"]
+        else:
+            return []
+
+        out = []
+        for e in entries:
+            sg_name = e["key"]
+            if sub_game is not None and sg_name != sub_game:
+                continue
+            # value is the struct FortUserBindingsPerSubGame-like: has UserActionBindings ArrayProperty
+            sv = e["value"]
+            if not isinstance(sv, dict):
+                continue
+            props = sv.get("__props__", [])
+            user_bindings = find_property(props, "UserActionBindings")
+            if user_bindings is None or not isinstance(user_bindings.value, dict):
+                continue
+            items = user_bindings.value.get("items", [])
+            for item in items:
+                if isinstance(item, dict):
+                    item["__sub_game__"] = sg_name  # ephemeral hint for callers
+                    out.append(item)
+        return out
+
+    @staticmethod
+    def get_keybinds(parsed: ClientSettingsFile, sub_game: str = "ESubGame::Athena") -> list[dict]:
+        """Return a list of {action, group, key1, key2, input_scale, is_axis}."""
+        result = []
+        for b in ClientSettingsManager._iter_bindings(parsed, sub_game=sub_game):
+            props = b.get("__props__", [])
+            def pget(name, default=None):
+                p = find_property(props, name)
+                return p.value if p is not None else default
+            k1 = pget("KeyBind1", {})
+            k2 = pget("KeyBind2", {})
+
+            # KeyBind{1,2} is a struct with a single NameProperty "KeyName"
+            def name_of(kb):
+                if isinstance(kb, dict):
+                    props2 = kb.get("__props__", [])
+                    p = find_property(props2, "KeyName")
+                    return p.value if p is not None else None
+                return None
+
+            result.append({
+                "action": pget("ActionName"),
+                "group": pget("ActionGroup"),
+                "key1": name_of(k1),
+                "key2": name_of(k2),
+                "input_scale": pget("InputScale"),
+                "is_axis": pget("bIsAxisMapping"),
+            })
+        return result
+
+    @staticmethod
+    def set_keybind(
+        parsed: ClientSettingsFile,
+        action: str,
+        *,
+        key1: str | None = None,
+        key2: str | None = None,
+        sub_game: str = "ESubGame::Athena",
+        input_scale: float | None = None,
+    ) -> int:
+        """Update the named action's KeyBind1/KeyBind2 (and optionally InputScale).
+
+        Returns the number of bindings matched (since some actions have
+        multiple entries, e.g. axis mappings).
+        """
+        hits = 0
+        for b in ClientSettingsManager._iter_bindings(parsed, sub_game=sub_game):
+            props = b.get("__props__", [])
+            action_prop = find_property(props, "ActionName")
+            if action_prop is None or action_prop.value != action:
+                continue
+
+            if key1 is not None:
+                kb1 = find_property(props, "KeyBind1")
+                if kb1 is not None and isinstance(kb1.value, dict):
+                    kb1_props = kb1.value.get("__props__", [])
+                    kn = find_property(kb1_props, "KeyName")
+                    if kn is not None:
+                        kn.value = key1
+            if key2 is not None:
+                kb2 = find_property(props, "KeyBind2")
+                if kb2 is not None and isinstance(kb2.value, dict):
+                    kb2_props = kb2.value.get("__props__", [])
+                    kn = find_property(kb2_props, "KeyName")
+                    if kn is not None:
+                        kn.value = key2
+            if input_scale is not None:
+                p = find_property(props, "InputScale")
+                if p is not None:
+                    p.value = float(input_scale)
+            hits += 1
+        return hits
+
+    # ------------------------------ apply -----------------------------------
+
+    def apply_changes(
+        self,
+        parsed: ClientSettingsFile,
+        *,
+        push_cloud: bool = True,
+        write_local: bool = True,
+        require_game_closed: bool = True,
+    ) -> dict:
+        """Persist edits: optionally write local, optionally push to cloud.
+
+        Returns a small dict describing what happened.
+        """
+        out: dict[str, Any] = {}
+        if write_local:
+            path = self.write_local(parsed, require_game_closed=require_game_closed)
+            out["local_path"] = str(path)
+        if push_cloud:
+            data = serialize_file(parsed)
+            self.cloud.upload(CLIENT_SETTINGS_FILENAME, data)
+            out["cloud_uploaded_bytes"] = len(data)
+        return out

--- a/lib/utilities/utilities.py
+++ b/lib/utilities/utilities.py
@@ -332,6 +332,7 @@ Sync Current Map To Reload Rotation =  "Queries fortnite.gg for the current Relo
 Create Custom P O I = backslash "Creates a custom P O I at the players current position while the full-screen map is open, and prompts the user for a name."
 Open Gamemode Selector = apostrophe "Opens the Gamemode Selector GUI, used for selecting which gamemode the user wants to play."
 Open Configuration Menu = f9 "Opens the FA11y configuration menu for changing these settings."
+Open Client Settings = lalt+lshift+c "Opens the Client Settings editor for viewing and modifying Fortnite's in-game settings (mouse sensitivity, audio volumes, keybinds, region, voice chat, toggles). Edits can be saved to your local file and pushed to your Epic cloud storage so they follow you across devices."
 Exit Match = f12 "Exits the current match while the in-game quick-menu is open."
 Detect Hotbar 1 = 1 "Announces details about the item the player is currently holding in slot 1."
 Detect Hotbar 2 = 2 "Announces details about the item the player is currently holding in slot 2."


### PR DESCRIPTION
## Summary
Adds an accessible wxPython editor for Fortnite's `ClientSettings.Sav` — the binary file Fortnite stores mouse sensitivity, FOV, audio volumes, keybinds, region, voice chat, and various toggles in. The editor can also push/pull the file to/from Epic cloud storage using FA11y's existing `EpicAuth` session, so settings follow the user across devices.

## What's new
- **Parser** (`lib/utilities/clientsettings_parser.py`) — reads/writes the `ClientSettings.Sav` property tree (typed values, keybind entries).
- **Cloud client** (`lib/utilities/clientsettings_cloud.py`) — uploads/downloads the save via Epic cloud storage.
- **Sync layer** (`lib/utilities/clientsettings_sync.py`) — local/cloud management, diffing, Fortnite-running detection, safe writes.
- **CLI** (`lib/utilities/clientsettings_cli.py`) — scriptable alternative to the GUI.
- **GUI** (`lib/guis/clientsettings_gui.py`) — three-tab notebook (Settings / Keybinds / Cloud) built on the existing accessible form helpers.

## Integration
- Registers a new keybind handler `'open client settings'` in `FA11y.py` with a default of `LAlt+LShift+C`.
- No changes to existing behavior; the editor is purely additive.

## Test plan
- [ ] Launch FA11y and press `LAlt+LShift+C` — editor opens without error.
- [ ] Load local `ClientSettings.Sav`, verify Settings / Keybinds tabs populate.
- [ ] Edit a value, save locally, reopen, confirm it persisted.
- [ ] Cloud tab: Pull / Diff / Push cycle with a logged-in Epic account.
- [ ] Close Fortnite before pushing (editor should warn if it's running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)