### PR TITLE
FA11y-OW: SSE-based companion client + initial consumer wiring

### DIFF
--- a/FA11y.py
+++ b/FA11y.py
@@ -255,6 +255,13 @@ def signal_handler(signum, frame):
         match_event_monitor.stop_monitoring()
         match_tracker.stop_monitoring()
 
+        # Stop the FA11y-OW SSE subscriber so we don't dangle on shutdown.
+        try:
+            from lib.utilities.fa11y_ow_client import get_client as _get_ow_client
+            _get_ow_client().stop()
+        except Exception:
+            pass
+
         # Stop social manager
         if social_manager:
             social_manager.stop_monitoring()
@@ -815,7 +822,13 @@ def main() -> None:
         # Start auxiliary systems — height_monitor is a BaseMonitor that
         # spawns its own daemon thread, so no outer wrapper needed.
         start_height_monitor()
-        
+
+        # Start the FA11y-OW companion client (SSE subscriber). Idempotent
+        # and harmless if FA11y-OW isn't running — it will reconnect on its
+        # own once the companion appears.
+        from lib.utilities.fa11y_ow_client import get_client as _get_ow_client
+        _get_ow_client()
+
         # Start monitoring systems
         monitor.start_monitoring()
         material_monitor.start_monitoring()
@@ -991,6 +1004,13 @@ def main() -> None:
             storm_monitor.stop_monitoring()
             match_event_monitor.stop_monitoring()
             match_tracker.stop_monitoring()
+
+            # Stop the FA11y-OW SSE subscriber so we don't dangle on shutdown.
+            try:
+                from lib.utilities.fa11y_ow_client import get_client as _get_ow_client
+                _get_ow_client().stop()
+            except Exception:
+                pass
 
             # Stop social manager
             if social_manager:

--- a/lib/detection/hsr.py
+++ b/lib/detection/hsr.py
@@ -4,18 +4,15 @@ Health / Shield / Rarity (HSR) detection.
 Two-path strategy:
 
 1. **Fast path — FA11y-OW companion service**
-   If a loopback HTTP service is running at ``http://127.0.0.1:6767/api``
-   (the "FA11y-OW" helper, a separate optional project) it gets queried
-   first. The service reads Fortnite memory/log signals directly and
-   returns exact values, bypassing image analysis.
-
-   The 10 ms timeout below is intentional: if the service isn't up, we
-   fall through instantly rather than block the UI. No state is kept
-   between calls; every H / shield keypress hits the endpoint fresh.
+   If the FA11y-OW helper (an optional Electron + Overwolf companion app)
+   is running, it exposes a local HTTP+SSE API at ``127.0.0.1:6767``.
+   ``lib.utilities.fa11y_ow_client`` keeps a live cached state snapshot
+   by tailing the SSE stream on a daemon thread, so reading health/shield
+   here is just a dict lookup — no per-call HTTP, no timeout dance.
 
 2. **Fallback — visual bar scan**
-   When the service is unreachable (the common case), the functions below
-   walk the health/shield bars pixel-by-pixel against the calibrated
+   When the companion is unreachable (the common case), the functions
+   below walk the health/shield bars pixel-by-pixel against the calibrated
    ``health_decreases`` step pattern. This is what ships by default and is
    what the user's F9 settings actually tune.
 
@@ -26,14 +23,9 @@ from accessible_output2.outputs.auto import Auto
 from lib.utilities.utilities import read_config, get_config_boolean
 from lib.managers.hotbar_manager import get_last_detected_rarity
 from lib.detection.coordinate_config import get_health_shield_coords
-import requests
+from lib.utilities.fa11y_ow_client import get_client
 
 speaker = Auto()
-
-# Optional companion service (FA11y-OW). If not running, requests fail
-# instantly and we fall back to the visual bar scan below.
-API_BASE_URL = "http://127.0.0.1:6767/api"
-API_TIMEOUT = 0.01
 
 # Visual detection fallback settings
 health_color, shield_color = (247, 255, 26), (213, 255, 232)
@@ -66,31 +58,21 @@ def check_value_visual(pixels, start_x, y, decreases, color, tolerance, name, no
     speaker.speak(no_value_msg)
 
 def get_health_shield_from_api():
+    """Read health, shield, and overshield from the FA11y-OW cached state.
+
+    Returns (health, shield, overshield) when the companion is connected,
+    or (None, None, None) so the caller falls back to visual detection.
     """
-    Try to get health, shield, and overshield values from the FA11y-OW HTTP API.
-    Returns (health, shield, overshield) tuple if successful, or (None, None, None) if API is unavailable.
-    """
-    try:
-        # Get health
-        health_response = requests.get(f"{API_BASE_URL}/health", timeout=API_TIMEOUT)
-        health_data = health_response.json()
-        health = health_data.get('health')
-        
-        # Get shield and overshield (both in same endpoint)
-        shield_response = requests.get(f"{API_BASE_URL}/shield", timeout=API_TIMEOUT)
-        shield_data = shield_response.json()
-        shield = shield_data.get('shield')
-        overshield = shield_data.get('overShield')
-        
-        # Only return if health and shield are valid numbers
-        if health is not None and shield is not None:
-            return (health, shield, overshield or 0)
+    client = get_client()
+    if not client.is_connected:
         return (None, None, None)
-        
-    except (requests.RequestException, requests.Timeout, ValueError, KeyError) as e:
-        # API not available, connection failed, or invalid response
-        # Silently fall back to visual detection
+    health = client.get('health')
+    shield = client.get('shield')
+    overshield = client.get('overShield')
+    if health is None or shield is None:
         return (None, None, None)
+    return (health, shield, overshield or 0)
+
 
 def check_health_shields():
     """Check and announce health and shield values using API first, visual fallback."""

--- a/lib/detection/match_tracker.py
+++ b/lib/detection/match_tracker.py
@@ -55,11 +55,27 @@ class MatchTracker:
         self.position_update_interval = 0.5  # Configurable
         self.current_player_position = None
 
+        # Debounce so the height-bar trigger and the FA11y-OW phase trigger
+        # don't both fire _start_new_match for the same transition.
+        self._last_new_match_time = 0.0
+        self._new_match_debounce_seconds = 10.0
+        self._last_phase_seen: Optional[str] = None
+
         # Cached config values (updated via config change events)
         self._cached_config = read_config()
         self._cached_current_map = self._cached_config.get('POI', 'current_map', fallback='main')
         self._cached_announce_new_match = get_config_boolean(self._cached_config, 'AnnounceNewMatch', True)
         on_config_change(self._on_config_change)
+
+        # Subscribe to FA11y-OW phase transitions as a more reliable
+        # new-match trigger than the height-bar heuristic. The listener is
+        # a no-op when FA11y-OW isn't running (the SSE thread just stays
+        # disconnected and never delivers events).
+        try:
+            from lib.utilities.fa11y_ow_client import get_client
+            get_client().on_event('phase', self._on_ow_phase)
+        except Exception:
+            pass
 
     def _on_config_change(self, config):
         """Update cached config values when config changes."""
@@ -159,22 +175,45 @@ class MatchTracker:
         except Exception:
             pass
     
+    def _on_ow_phase(self, changed_key: str, state: dict):
+        """Listener for FA11y-OW 'phase' state changes.
+
+        GEP reports phase as one of 'lobby', 'aircraft', 'airfield', etc.
+        A transition into aircraft/airfield is a new match. We debounce
+        against the height-bar trigger so the same match doesn't get
+        started twice.
+        """
+        phase = state.get('phase')
+        prev = self._last_phase_seen
+        self._last_phase_seen = phase
+        if phase in ('aircraft', 'airfield') and prev not in ('aircraft', 'airfield'):
+            print(f"FA11y-OW phase -> {phase}, starting new match")
+            self._start_new_match()
+
     def _start_new_match(self):
         """Start a new match session"""
         with self.match_lock:
+            # Debounce: ignore triggers within the debounce window so the
+            # height-bar heuristic and the FA11y-OW phase listener don't
+            # both fire for the same transition.
+            now = time.time()
+            if now - self._last_new_match_time < self._new_match_debounce_seconds:
+                return
+            self._last_new_match_time = now
+
             # Close current match if active
             if self.current_match and self.current_match.is_active:
                 self.current_match.is_active = False
                 self.match_history.append(self.current_match)
                 print(f"Match {self.current_match.match_id[:8]} completed")
-            
+
             # Start new match
             self.current_match = MatchSession()
             print(f"New match started: {self.current_match.match_id[:8]}")
-            
+
             # Clear visited objects cache
             self._clear_visited_objects_cache()
-            
+
             # Announce if configured
             if self._cached_announce_new_match:
                 self.speaker.speak("New match started")

--- a/lib/utilities/fa11y_ow_client.py
+++ b/lib/utilities/fa11y_ow_client.py
@@ -1,0 +1,206 @@
+"""
+FA11y-OW companion client.
+
+Subscribes to the FA11y-OW Electron app's local HTTP API at 127.0.0.1:6767.
+That app uses Overwolf's Game Events Provider (GEP) to mirror Fortnite state
+and exposes it both as REST endpoints and as a Server-Sent Events stream.
+
+This module keeps a live cached state snapshot in-memory by tailing the SSE
+stream on a daemon thread, and lets consumers either pull a value
+synchronously or register a callback for state changes.
+
+When FA11y-OW is not running, is_connected stays False and get(...) returns
+the supplied default. Consumers use that signal to fall back to their
+existing visual detection path.
+"""
+
+import json
+import logging
+import threading
+from typing import Any, Callable, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "http://127.0.0.1:6767/api"
+SSE_URL = f"{BASE_URL}/subscribe"
+
+# Connect timeout for the SSE handshake. Read timeout is intentionally None:
+# once we're streaming, an idle period just means the game state hasn't
+# changed and the server's 30s heartbeat will tickle the socket.
+SSE_CONNECT_TIMEOUT = 2.0
+
+# Backoff between reconnect attempts when the companion isn't reachable.
+# Keep this short enough that the user doesn't have to wait long after
+# launching FA11y-OW for FA11y to pick it up.
+SSE_RECONNECT_DELAY = 3.0
+
+
+class FA11yOWClient:
+    """Live client for the FA11y-OW HTTP API.
+
+    Single instance per process — use get_client() to obtain it. Starts a
+    background thread on first start() that maintains the SSE subscription
+    and reconnects on its own if the companion is restarted.
+    """
+
+    def __init__(self):
+        self._state: dict = {}
+        self._lock = threading.RLock()
+        self._connected = False
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # changed_key -> [callback(changed_key, full_state), ...]
+        self._listeners: dict = {}
+
+    def start(self):
+        """Start the SSE subscriber thread. Idempotent."""
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._run, daemon=True, name='FA11y-OW-Client'
+            )
+            self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        thread = self._thread
+        if thread:
+            thread.join(timeout=2.0)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def get_state(self) -> Optional[dict]:
+        """Shallow copy of the cached state, or None if disconnected."""
+        with self._lock:
+            if not self._connected:
+                return None
+            return dict(self._state)
+
+    def get(self, *path: str, default: Any = None) -> Any:
+        """Read a value from cached state by key path.
+
+        Returns default if disconnected or any path component is missing.
+
+            client.get('health')          # 100
+            client.get('location', 'x')   # nested
+            client.get('inventory')       # the whole inventory dict
+        """
+        with self._lock:
+            if not self._connected:
+                return default
+            value: Any = self._state
+            for key in path:
+                if not isinstance(value, dict) or key not in value:
+                    return default
+                value = value[key]
+            return value
+
+    def on_event(self, changed_key: str, callback: Callable[[str, dict], None]):
+        """Register a callback fired when SSE reports a state change.
+
+        changed_key is the GEP key name ('phase', 'health', 'kill', 'death',
+        'matchStart', 'matchEnd', 'selected_slot', 'item_X', ...). Use '*' to
+        receive every change.
+
+        callback signature: (changed_key, state_snapshot) -> None
+        Callbacks run on the SSE thread; keep them short and don't block.
+        """
+        with self._lock:
+            self._listeners.setdefault(changed_key, []).append(callback)
+
+    # --- Internal -------------------------------------------------------
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                self._stream_session()
+            except Exception as e:
+                logger.debug(f"FA11y-OW SSE session error: {e}")
+            self._set_connected(False)
+            if self._stop_event.wait(SSE_RECONNECT_DELAY):
+                return
+
+    def _stream_session(self):
+        """One SSE connection lifetime. Returns on disconnect or stop."""
+        try:
+            response = requests.get(
+                SSE_URL,
+                stream=True,
+                timeout=(SSE_CONNECT_TIMEOUT, None),
+                headers={'Accept': 'text/event-stream'},
+            )
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout):
+            # Expected when companion isn't running — caller will back off.
+            return
+
+        with response:
+            if response.status_code != 200:
+                return
+            self._set_connected(True)
+            for raw in response.iter_lines(decode_unicode=True):
+                if self._stop_event.is_set():
+                    return
+                if not raw or not raw.startswith('data: '):
+                    continue
+                payload = raw[6:]
+                try:
+                    msg = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                self._handle_message(msg)
+
+    def _handle_message(self, msg: dict):
+        msg_type = msg.get('type')
+        if msg_type not in ('connected', 'stateChange'):
+            return
+        data = msg.get('data')
+        if not isinstance(data, dict):
+            return
+        with self._lock:
+            self._state = data
+        self._fire_listeners(msg.get('changedKey'), data)
+
+    def _fire_listeners(self, changed_key: Optional[str], state: dict):
+        with self._lock:
+            specific = list(self._listeners.get(changed_key, [])) if changed_key else []
+            wildcard = list(self._listeners.get('*', []))
+        for cb in specific + wildcard:
+            try:
+                cb(changed_key or '', state)
+            except Exception as e:
+                logger.debug(f"FA11y-OW listener error: {e}")
+
+    def _set_connected(self, value: bool):
+        with self._lock:
+            was = self._connected
+            self._connected = value
+        if was and not value:
+            logger.info("FA11y-OW disconnected")
+        elif not was and value:
+            logger.info("FA11y-OW connected")
+
+
+_client: Optional[FA11yOWClient] = None
+_client_lock = threading.Lock()
+
+
+def get_client() -> FA11yOWClient:
+    """Return the process-wide singleton client, starting it on first call."""
+    global _client
+    with _client_lock:
+        if _client is None:
+            _client = FA11yOWClient()
+            _client.start()
+        return _client
+
+
+def is_available() -> bool:
+    """True iff the companion app is currently connected."""
+    return get_client().is_connected


### PR DESCRIPTION
## Summary

Adds a singleton client that subscribes to FA11y-OW's local SSE stream (`/api/subscribe`) on a daemon thread and keeps a live cached state snapshot. Consumers read from cache (`client.get('health')`) or register listeners (`client.on_event('phase', cb)`); when FA11y-OW isn't running, `is_connected` stays `False` and every consumer transparently falls back to its existing visual detection.

This is the foundation. Two consumers are migrated as the reference pattern; the rest are blocked on FA11y-OW changes (separate writeup with @greenbeangravy).

### Files

**New** — `lib/utilities/fa11y_ow_client.py`
- `FA11yOWClient` — SSE subscriber, thread-safe state cache, listener API, auto-reconnect with 3s backoff
- `get_client()` singleton + `is_available()` convenience

**Modified — consumers**
- `lib/detection/hsr.py` — drops the inline `requests.get` with 10ms timeout for a dict lookup against cached state. Same return contract; visual fallback path untouched.
- `lib/detection/match_tracker.py` — listens for `phase` transitions to `aircraft`/`airfield` as a primary new-match trigger. Existing height-bar heuristic kept as fallback; new 10s debounce in `_start_new_match` prevents both paths firing for the same transition.

**Modified — wiring**
- `FA11y.py` — starts the client alongside other monitors; stops it cleanly on both shutdown paths (signal handler + main exit).

## Why SSE instead of polling

The old `hsr.py` did a fresh `requests.get(...)` with a 10ms timeout on every keypress. With SSE, the values are already in memory the moment the screen reader announces them — no per-call HTTP, no timeout dance, and the same architecture handles every other field FA11y-OW exposes (kills, deaths, phase, accuracy, location, ...) without each consumer needing its own endpoint logic.

## What's deferred

I started on hotbar/inventory migration but pulled back: confirmed in the FA11y-OW source that `inventory.item_*` and `selectedSlot` are stored as raw `JSON.parse(value)` blobs without a documented field shape. Writing a Python consumer against unknown JSON is fragile. Same story for material counts, storm/zone, bus line, kill feed — either not parsed yet or shape isn't stable.

Separate doc going to @greenbeangravy listing seven asks for FA11y-OW (stable hotbar endpoint with documented shape, material counts via the already-registered `counters` GEP feature, storm/zone parsing, bus line, kill feed, source repo access for PRs, optional `/api/raw` catch-all).

## Test plan

- [ ] Run FA11y without FA11y-OW: confirm health/shield announce uses visual fallback as before, no regression.
- [ ] Run FA11y with FA11y-OW: confirm health/shield announce uses API path (logs show "FA11y-OW connected").
- [ ] Confirm match_tracker fires `_start_new_match` once per match-start, not twice (debounce works against both height-bar and phase trigger).
- [ ] Stop FA11y-OW mid-session: confirm consumers fall back to visual without crashing or freezing.
- [ ] Restart FA11y-OW: confirm client reconnects within ~3s.
- [ ] Shutdown via Ctrl+C and via main exit: confirm SSE thread terminates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)